### PR TITLE
Crisis lex integration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,7 @@
 {
     "rules": {
         "no-console": "off",
-        "indent": [
-            2,
-            4
-        ],
+        "indent": ["error", 2]
         "quotes": [
             2,
             "single"

--- a/.eslintrc
+++ b/.eslintrc
@@ -22,5 +22,9 @@
         "es6": true,
         "node": true
     },
-    "extends": "eslint:recommended"
+    "extends": "eslint:recommended",
+    "globals": {
+          "it": false,
+          "describe": false
+     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
     "rules": {
         "no-console": "off",
-        "indent": ["error", 2]
+        "indent": ["error", 2],
         "quotes": [
             2,
             "single"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# IDEA config files
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
     "async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
@@ -211,6 +217,12 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
     "browserify-mime": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
@@ -260,10 +272,22 @@
       "dev": true,
       "optional": true
     },
+    "chai": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
+      "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
+      "dev": true
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "circular-json": {
       "version": "0.3.1",
@@ -420,6 +444,20 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "deep-eql": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
+      "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
+      "dev": true,
+      "dependencies": {
+        "type-detect": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
+          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
+          "dev": true
+        }
+      }
+    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -464,6 +502,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
     },
     "doctrine": {
       "version": "1.5.0",
@@ -721,6 +765,12 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
       "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w="
     },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true
+    },
     "formidable": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
@@ -774,6 +824,12 @@
       "resolved": "https://registry.npmjs.org/geotile/-/geotile-0.1.10.tgz",
       "integrity": "sha1-/8nzDs1gPza/ioBAQG2ImnK260w="
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -819,6 +875,12 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.7.2.tgz",
       "integrity": "sha1-zIlKMoIzmbigywErnp7K01zQD3I="
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
     },
     "handlebars": {
       "version": "4.0.10",
@@ -1145,6 +1207,12 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -1223,6 +1291,66 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+      "dev": true
+    },
     "long": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
@@ -1282,6 +1410,38 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true
     },
+    "mocha": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true
+        }
+      }
+    },
     "moment": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
@@ -1296,6 +1456,12 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
     "nconf": {
@@ -1439,6 +1605,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "performance-now": {
       "version": "0.2.0",
@@ -1689,6 +1861,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
       "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ=="
     },
+    "samsam": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
+      "dev": true
+    },
     "sax": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.2.tgz",
@@ -1724,6 +1902,26 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
+    },
+    "sinon": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.4.tgz",
+      "integrity": "sha1-RmrY0brobW21GqIYuS6Ze8Pl24g=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true
+        }
+      }
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -1913,6 +2111,12 @@
         }
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -1970,6 +2174,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
       "dev": true
     },
     "type-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -194,6 +194,11 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g="
     },
+    "bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+    },
     "body-parser": {
       "version": "1.17.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2140 @@
+{
+  "name": "fortis-services",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo="
+    },
+    "acorn": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ap": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz",
+      "integrity": "sha1-rglCYAspkS8NKxTsYMRejzMLYRA="
+    },
+    "applicationinsights": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.16.0.tgz",
+      "integrity": "sha1-4C2vsQz1c8GbQpeTyHeX1kBPDuM="
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+    },
+    "async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
+      "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "azure-storage": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-1.4.0.tgz",
+      "integrity": "sha1-+1L6aLPvppgMM/18XNSJt63EbtE=",
+      "dependencies": {
+        "request": {
+          "version": "2.74.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+          "dependencies": {
+            "extend": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+            }
+          }
+        },
+        "xml2js": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.7.tgz",
+          "integrity": "sha1-GDhRi7AXQcrgh4urSRXklMMjBq8="
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true
+    },
+    "bl": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g="
+    },
+    "body-parser": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
+      "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
+      "dependencies": {
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+        }
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true
+    },
+    "browserify-mime": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
+      "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
+    },
+    "buffer-writer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
+      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
+    },
+    "bytes": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+      "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+    },
+    "circular-json": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "dev": true
+    },
+    "cjson": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.2.1.tgz",
+      "integrity": "sha1-c82KrWXZ4VBfmvF0TTt5wVJ2gqU="
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true
+    },
+    "cli-width": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "colors": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+      "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dev": true
+        }
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-type": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
+      "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4="
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true
+    },
+    "ebnf-parser": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
+      "integrity": "sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+    },
+    "es-abstract": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
+      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
+      "dev": true
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true
+    },
+    "es5-ext": {
+      "version": "0.10.23",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
+      "dev": true
+    },
+    "es6-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "dev": true
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.21.tgz",
+      "integrity": "sha1-U9ZSz6EDA4gnlFilJmxf/HCcY8M=",
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+        }
+      }
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "dependencies": {
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
+        }
+      }
+    },
+    "eslint": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+      "dev": true,
+      "dependencies": {
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
+        }
+      }
+    },
+    "espree": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
+      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+      "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
+    },
+    "esrecurse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "dev": true,
+      "dependencies": {
+        "estraverse": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz",
+      "integrity": "sha1-AaCTLf7ldGhKWYr1pnw7+bZCjbI="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "express": {
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
+      "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
+      "dependencies": {
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+        }
+      }
+    },
+    "express-graphql": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.5.4.tgz",
+      "integrity": "sha1-QTR34+/abXQ354j372yZSRTnn4g="
+    },
+    "extend": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
+      "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true
+    },
+    "finalhandler": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
+      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk="
+    },
+    "flat-cache": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "dev": true
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "dev": true
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w="
+    },
+    "formidable": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+      "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk=",
+      "dev": true
+    },
+    "forwarded": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+    },
+    "fresh": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
+    },
+    "generic-pool": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
+      "integrity": "sha1-eAw29p360FpaBF3Te+etyhGk9v8="
+    },
+    "geopoint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/geopoint/-/geopoint-1.0.1.tgz",
+      "integrity": "sha1-CNsASLTLk1ut1fmiwLLiB8pLfyQ="
+    },
+    "geotile": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/geotile/-/geotile-0.1.10.tgz",
+      "integrity": "sha1-/8nzDs1gPza/ioBAQG2ImnK260w="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "graphql": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.7.2.tgz",
+      "integrity": "sha1-zIlKMoIzmbigywErnp7K01zQD3I="
+    },
+    "handlebars": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true
+        }
+      }
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0="
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "http-errors": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc="
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+    },
+    "iconv-lite": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+      "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
+    },
+    "ignore": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "ipaddr.js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
+      "integrity": "sha1-HgOlL9rYOou7KyXL9JmLTP/NPew="
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM="
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "escodegen": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+          "dev": true
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true
+        }
+      }
+    },
+    "iterall": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.0.2.tgz",
+      "integrity": "sha1-QaLpbOntpeYcdn7l3DEjc7sEbpE="
+    },
+    "jison": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/jison/-/jison-0.4.13.tgz",
+      "integrity": "sha1-kEFwfWIkE2f1iDRTK58ZwsNvrHg=",
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+        }
+      }
+    },
+    "jison-lex": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jison-lex/-/jison-lex-0.2.1.tgz",
+      "integrity": "sha1-rEuBXozOUTLrErXfz+jXB7iETf4="
+    },
+    "js-yaml": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+      "dev": true,
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-edm-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
+      "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonparse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+      "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
+    },
+    "jsonpath": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-0.2.11.tgz",
+      "integrity": "sha1-v+IuBmW5cS+Oe99+Lh+MCLWUxg4=",
+      "dependencies": {
+        "underscore": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+        }
+      }
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+    },
+    "JSONSelect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
+      "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40="
+    },
+    "jsprim": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true
+    },
+    "lex-parser": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/lex-parser/-/lex-parser-0.1.4.tgz",
+      "integrity": "sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+    },
+    "mime-db": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+    },
+    "mime-types": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true
+    },
+    "moment": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "nconf": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.8.4.tgz",
+      "integrity": "sha1-lQIjT3rWI4yrf5LXwGjCBDTT/5M=",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "nomnom": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+      "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
+      "dependencies": {
+        "underscore": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+          "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA="
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+    },
+    "object-inspect": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.2.2.tgz",
+      "integrity": "sha1-yCEV5PzIiK6hTWTCLk8X9qcNXlo=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
+    },
+    "packet-reader": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
+      "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
+    },
+    "parseurl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+    },
+    "pg": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-6.2.4.tgz",
+      "integrity": "sha1-T37ecCQel1BmJ9XWB4NgcBpkfEU="
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "pg-pool": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.7.1.tgz",
+      "integrity": "sha1-QhEFy3Rpl53MSNb8T+P+RllDdDc="
+    },
+    "pg-types": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.0.tgz",
+      "integrity": "sha1-itO3uJfj/UY+Yt4kGtX8ZAtKZvA="
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY="
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "postgres-array": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz",
+      "integrity": "sha1-jgsy6wO/d6XAp4UeBEHBaaJWojg="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+    },
+    "postgres-client": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-client/-/postgres-client-1.0.1.tgz",
+      "integrity": "sha1-bb93D2As3YGy1UjIclJYjrQL3Lk="
+    },
+    "postgres-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
+      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g="
+    },
+    "postgres-interval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.0.tgz",
+      "integrity": "sha1-EDHnusNFZBMoYq3J62xtLzqnW7Q="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8="
+    },
+    "proxy-addr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
+      "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y="
+    },
+    "readable-stream": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44="
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true
+    },
+    "reduce-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+      "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "dependencies": {
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+        }
+      }
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "dev": true
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+      "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ=="
+    },
+    "sax": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.2.tgz",
+      "integrity": "sha1-c1/6o5oc/4/7lZjwIjq9sDqfsuo="
+    },
+    "secure-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+      "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+    },
+    "semver": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+    },
+    "send": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
+      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk="
+    },
+    "serve-static": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
+      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI="
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+    },
+    "shelljs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "optional": true
+    },
+    "split": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+      "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "static-eval": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.3.tgz",
+      "integrity": "sha1-Aj8XrJ/uQm6niMEuo5IG3Bdfiyo=",
+      "dependencies": {
+        "escodegen": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+          "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M="
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+        },
+        "estraverse": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+          "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI="
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "superagent": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.5.tgz",
+      "integrity": "sha1-HA3cOvMOgOuE68BcshItqP6UC1U=",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "extend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "1.0.0-rc3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+          "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "qs": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.27-1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+          "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-1.2.0.tgz",
+      "integrity": "sha1-hQp5X5Bo0vrxngF5n/CZYuDOQ74=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "table": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "dev": true
+        }
+      }
+    },
+    "tape": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.6.3.tgz",
+      "integrity": "sha1-Y353WB6ass4XV36b1M5PV1gG2LY=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+    },
+    "tryit": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+    },
+    "turf-bbox-polygon": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/turf-bbox-polygon/-/turf-bbox-polygon-3.0.12.tgz",
+      "integrity": "sha1-Mw3AuzgyLWFUXflmzmyA9oWs9PI="
+    },
+    "turf-helpers": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/turf-helpers/-/turf-helpers-3.0.12.tgz",
+      "integrity": "sha1-3UJy50s618lu7LeuXFf+jspUS3s="
+    },
+    "turf-inside": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/turf-inside/-/turf-inside-3.0.12.tgz",
+      "integrity": "sha1-m6QPpu7WO+x+fYiqZCdiLE3wcGY="
+    },
+    "turf-invariant": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/turf-invariant/-/turf-invariant-3.0.12.tgz",
+      "integrity": "sha1-O5UlOVOZHr2WLdNdT2cEwofejr4="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true,
+          "optional": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "optional": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+    },
+    "validator": {
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-3.22.2.tgz",
+      "integrity": "sha1-byl65n9/gqzHbQr9tJ8Y2aCcGMA="
+    },
+    "vary": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+    },
+    "verror": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+    },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "dev": true
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "dependencies": {
+        "sax": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
+          "integrity": "sha1-/YYxojvHgmvvXYcb24c3jJVkeCg="
+        },
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU="
+        }
+      }
+    },
+    "xmlbuilder": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz",
+      "integrity": "sha1-xGFLp04K0ZbmCcknLNnh3bKKilg="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,6 +248,11 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
+    "cassandra-driver": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-3.2.2.tgz",
+      "integrity": "sha1-vLrhUWkUHfCLTjLUd/pYuZ6sUEA="
+    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -1217,6 +1222,11 @@
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "long": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
+      "integrity": "sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8="
     },
     "longest": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -177,6 +177,12 @@
         }
       }
     },
+    "babel-code-frame": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -282,6 +288,50 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
       "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
       "dev": true
+    },
+    "chai-as-promised": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.0.0.tgz",
+      "integrity": "sha512-7YYdnXPq2pV9nvRBb36Wi/MXfT8j2iL/H76GtenlOMatXbMoQLb+PonuVHGFsw5wE2M6R/VFciq8AnSSAix0GA==",
+      "dev": true,
+      "dependencies": {
+        "doctrine": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+          "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+          "dev": true
+        },
+        "eslint": {
+          "version": "3.19.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+          "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+          "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.7.8",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+          "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        }
+      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -650,6 +700,20 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
       "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
     },
+    "esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "dependencies": {
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
+        }
+      }
+    },
     "esrecurse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
@@ -993,6 +1057,12 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true
     },
+    "interpret": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+      "dev": true
+    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -1171,6 +1241,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/jison-lex/-/jison-lex-0.2.1.tgz",
       "integrity": "sha1-rEuBXozOUTLrErXfz+jXB7iETf4="
+    },
+    "js-tokens": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.8.4",
@@ -1469,6 +1545,12 @@
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "nconf": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.8.4.tgz",
@@ -1752,6 +1834,12 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true
+    },
     "reduce-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
@@ -2020,6 +2108,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "applicationinsights": "^0.16.0",
     "async": "^2.1.2",
     "azure-storage": "^1.3.2",
+    "bluebird": "^3.5.0",
     "body-parser": "^1.15.0",
     "cassandra-driver": "^3.2.2",
     "express": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "async": "^2.1.2",
     "azure-storage": "^1.3.2",
     "body-parser": "^1.15.0",
+    "cassandra-driver": "^3.2.2",
     "express": "^4.0.0",
     "express-graphql": "^0.5.4",
     "geopoint": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "chai": "^4.0.2",
+    "chai-as-promised": "^7.0.0",
     "eslint": "^2",
     "is-my-json-valid": "^2.13.1",
     "istanbul": "~0.4.3",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,13 @@
     "xml2js": "^0.4.17"
   },
   "devDependencies": {
+    "chai": "^4.0.2",
     "eslint": "^2",
-    "istanbul": "~0.4.3",
     "is-my-json-valid": "^2.13.1",
+    "istanbul": "~0.4.3",
     "js-yaml": "^3.2.6",
+    "mocha": "^3.4.2",
+    "sinon": "^2.3.4",
     "supertest": "^1.2.0",
     "tape": "^4"
   },

--- a/server.js
+++ b/server.js
@@ -22,17 +22,17 @@ var TopicsResolver = require('./src/resolvers/Topics');
 var app = express();
 
 app.use(function(req, res, next) {
-    res.header('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Credentials', true);
-    res.header('Access-Control-Allow-Methods', 'OPTIONS,GET,POST,PUT,DELETE');
-    res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-ms-meta-data*,x-ms-meta-target*,x-ms-meta-abc');
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Credentials', true);
+  res.header('Access-Control-Allow-Methods', 'OPTIONS,GET,POST,PUT,DELETE');
+  res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-ms-meta-data*,x-ms-meta-target*,x-ms-meta-abc');
 
    // intercept OPTIONS method
-    if ('OPTIONS' == req.method) {
-        res.sendStatus(200);
-    } else {
-        next();
-    }
+  if ('OPTIONS' == req.method) {
+    res.sendStatus(200);
+  } else {
+    next();
+  }
 });
 
 console.log('PORT: ' + port);
@@ -41,39 +41,39 @@ app.use(bodyParser.json({limit: '50mb'}));
 app.use(bodyParser.urlencoded({limit: '50mb', extended: true}));
 
 app.use('/api/messages', graphqlHTTP({
-    schema: SpatialMessageSchema,
-    rootValue: SpatialMessageResolver,
-    graphiql: true
+  schema: SpatialMessageSchema,
+  rootValue: SpatialMessageResolver,
+  graphiql: true
 }));
 
 app.use('/api/facts', graphqlHTTP({
-    schema: FactsSchema,
-    rootValue: FactsResolver,
-    graphiql: true
+  schema: FactsSchema,
+  rootValue: FactsResolver,
+  graphiql: true
 }));
 
 app.use('/api/edges', graphqlHTTP({
-    schema: EdgesSchema,
-    rootValue: EdgesResolver,
-    graphiql: true
+  schema: EdgesSchema,
+  rootValue: EdgesResolver,
+  graphiql: true
 }));
 
 app.use('/api/tiles', graphqlHTTP({
-    schema: TileSchema,
-    rootValue: TileResolver,
-    graphiql: true
+  schema: TileSchema,
+  rootValue: TileResolver,
+  graphiql: true
 }));
 
 app.use('/api/settings', graphqlHTTP({
-    schema: SettingsSchema,
-    rootValue: SettingsResolver,
-    graphiql: true
+  schema: SettingsSchema,
+  rootValue: SettingsResolver,
+  graphiql: true
 }));
 
 app.use('/api/topics', graphqlHTTP({
-    schema: TopicsSchema, //TODO change to TopicsSchema
-    rootValue: TopicsResolver,
-    graphiql: true
+  schema: TopicsSchema, //TODO change to TopicsSchema
+  rootValue: TopicsResolver,
+  graphiql: true
 }));
 
 var server = http.createServer(app);

--- a/server.js
+++ b/server.js
@@ -6,16 +6,18 @@ var http = require('http');
 var express = require('express');
 var bodyParser = require('body-parser');
 var graphqlHTTP = require('express-graphql');
-var SpatialMessageSchema = require('./src/schemas/MessageSchema');
-var SpatialMessageResolver = require('./src/resolvers/Messages');
-var FactsSchema = require('./src/schemas/FactSchema');
-var FactsResolver = require('./src/resolvers/Facts');
-var TileSchema = require('./src/schemas/TilesSchema');
-var TileResolver = require('./src/resolvers/Tiles');
-var EdgesSchema = require('./src/schemas/EdgesSchema');
-var EdgesResolver = require('./src/resolvers/Edges');
-var SettingsResolver = require('./src/resolvers/Settings');
-var SettingsSchema = require('./src/schemas/SettingsSchema');
+var SpatialMessageSchema = require("./src/schemas/MessageSchema");
+var SpatialMessageResolver = require("./src/resolvers/Messages");
+var FactsSchema = require("./src/schemas/FactSchema");
+var FactsResolver = require("./src/resolvers/Facts");
+var TileSchema = require("./src/schemas/TilesSchema");
+var TileResolver = require("./src/resolvers/Tiles");
+var EdgesSchema = require("./src/schemas/EdgesSchema");
+var EdgesResolver = require("./src/resolvers/Edges");
+var SettingsResolver = require("./src/resolvers/Settings");
+var SettingsSchema = require("./src/schemas/SettingsSchema");
+var TopicsSchema = require("./src/schemas/TopicsSchema");
+var TopicsResolver = require("./src/resolvers/Topics");
 
 var app = express();
 
@@ -66,6 +68,12 @@ app.use('/api/settings', graphqlHTTP({
     schema: SettingsSchema,
     rootValue: SettingsResolver,
     graphiql: true
+}));
+
+app.use('/api/topics', graphqlHTTP({
+  schema: TopicsSchema, //TODO change to TopicsSchema
+  rootValue: TopicsResolver,
+  graphiql: true,
 }));
 
 var server = http.createServer(app);

--- a/server.js
+++ b/server.js
@@ -71,7 +71,7 @@ app.use('/api/settings', graphqlHTTP({
 }));
 
 app.use('/api/topics', graphqlHTTP({
-  schema: TopicsSchema, //TODO change to TopicsSchema
+  schema: TopicsSchema,
   rootValue: TopicsResolver,
   graphiql: true
 }));

--- a/server.js
+++ b/server.js
@@ -6,18 +6,18 @@ var http = require('http');
 var express = require('express');
 var bodyParser = require('body-parser');
 var graphqlHTTP = require('express-graphql');
-var SpatialMessageSchema = require("./src/schemas/MessageSchema");
-var SpatialMessageResolver = require("./src/resolvers/Messages");
-var FactsSchema = require("./src/schemas/FactSchema");
-var FactsResolver = require("./src/resolvers/Facts");
-var TileSchema = require("./src/schemas/TilesSchema");
-var TileResolver = require("./src/resolvers/Tiles");
-var EdgesSchema = require("./src/schemas/EdgesSchema");
-var EdgesResolver = require("./src/resolvers/Edges");
-var SettingsResolver = require("./src/resolvers/Settings");
-var SettingsSchema = require("./src/schemas/SettingsSchema");
-var TopicsSchema = require("./src/schemas/TopicsSchema");
-var TopicsResolver = require("./src/resolvers/Topics");
+var SpatialMessageSchema = require('./src/schemas/MessageSchema');
+var SpatialMessageResolver = require('./src/resolvers/Messages');
+var FactsSchema = require('./src/schemas/FactSchema');
+var FactsResolver = require('./src/resolvers/Facts');
+var TileSchema = require('./src/schemas/TilesSchema');
+var TileResolver = require('./src/resolvers/Tiles');
+var EdgesSchema = require('./src/schemas/EdgesSchema');
+var EdgesResolver = require('./src/resolvers/Edges');
+var SettingsResolver = require('./src/resolvers/Settings');
+var SettingsSchema = require('./src/schemas/SettingsSchema');
+var TopicsSchema = require('./src/schemas/TopicsSchema');
+var TopicsResolver = require('./src/resolvers/Topics');
 
 var app = express();
 
@@ -71,9 +71,9 @@ app.use('/api/settings', graphqlHTTP({
 }));
 
 app.use('/api/topics', graphqlHTTP({
-  schema: TopicsSchema, //TODO change to TopicsSchema
-  rootValue: TopicsResolver,
-  graphiql: true,
+    schema: TopicsSchema, //TODO change to TopicsSchema
+    rootValue: TopicsResolver,
+    graphiql: true
 }));
 
 var server = http.createServer(app);

--- a/src/connectors/CassandraConnector.js
+++ b/src/connectors/CassandraConnector.js
@@ -6,40 +6,40 @@ const cassandra = Promise.promisifyAll(require('cassandra-driver'));
 const CASSANDRA_CONTACT_POINTS = process.env.CASSANDRA_CONTACT_POINTS;
 
 const options = {
-    contactPoints: [CASSANDRA_CONTACT_POINTS],
-    keyspace: process.env.CASSANDRA_KEYSPACE
+  contactPoints: [CASSANDRA_CONTACT_POINTS],
+  keyspace: process.env.CASSANDRA_KEYSPACE
 };
 
 module.exports = {
 
-    openClient: function () {
-        const client = new cassandra.Client(options);
+  openClient: function () {
+    const client = new cassandra.Client(options);
 
-        return new Promise((resolve, reject) => {
-            client.connect()
+    return new Promise((resolve, reject) => {
+      client.connect()
         .then(() => {
           //console.log('Connected to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys);
           //console.log('Keyspaces: %j', Object.keys(client.metadata.keyspaces));
-            resolve(client);
+          resolve(client);
         })
         .catch((err) => {
           //console.error('There was an error when connecting to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys, err);
-            client.shutdown();
-            reject(err);
+          client.shutdown();
+          reject(err);
         });
-        });
-    },
+    });
+  },
 
-    closeClient: function(client) {
-        return new Promise((resolve, reject) => {
-            client.shutdown()
+  closeClient: function(client) {
+    return new Promise((resolve, reject) => {
+      client.shutdown()
         .then(() => {
-            resolve();
+          resolve();
         })
         .catch((err) => {
           //console.error('There was an error shutting down the client');
-            reject(err);
+          reject(err);
         });
-        });
-    }
+    });
+  }
 };

--- a/src/connectors/CassandraConnector.js
+++ b/src/connectors/CassandraConnector.js
@@ -1,0 +1,25 @@
+"use strict"
+
+const cassandra = require('cassandra-driver');
+
+module.exports = {
+  getClient: function (contactPoints, keyspace) {
+    const client = new cassandra.Client({ contactPoints: contactPoints, keyspace: keyspace }); //http://docs.datastax.com/en/developer/nodejs-driver/3.2/api/type.ClientOptions/
+
+    client.connect(function (err) {
+      if (err) return console.error(err);
+      console.log('Connected to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys);
+    });
+  }
+}
+
+/* TODO ***********************************
+Add app insights for reporting errors:
+Connecting to cassandra
+Failed storage mutations
+
+unit test with mocha and sinon
+*/
+
+//let appInsights = require("applicationinsights");
+//let appInsightsClient = appInsights.getClient();

--- a/src/connectors/CassandraConnector.js
+++ b/src/connectors/CassandraConnector.js
@@ -1,45 +1,45 @@
-"use strict"
+'use strict';
 
-const Promise = require("bluebird");
+const Promise = require('bluebird');
 const cassandra = Promise.promisifyAll(require('cassandra-driver'));
 
 const CASSANDRA_CONTACT_POINTS = process.env.CASSANDRA_CONTACT_POINTS;
 
 const options = {
-  contactPoints: [CASSANDRA_CONTACT_POINTS],
-  keyspace: process.env.CASSANDRA_KEYSPACE
+    contactPoints: [CASSANDRA_CONTACT_POINTS],
+    keyspace: process.env.CASSANDRA_KEYSPACE
 };
 
 module.exports = {
 
-  openClient: function () {
-    const client = new cassandra.Client(options);
+    openClient: function () {
+        const client = new cassandra.Client(options);
 
-    return new Promise((resolve, reject) => {
-      client.connect()
+        return new Promise((resolve, reject) => {
+            client.connect()
         .then(() => {
           //console.log('Connected to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys);
           //console.log('Keyspaces: %j', Object.keys(client.metadata.keyspaces));
-          resolve(client);
+            resolve(client);
         })
         .catch((err) => {
           //console.error('There was an error when connecting to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys, err);
-          client.shutdown();
-          reject(null);
+            client.shutdown();
+            reject(null);
         });
-    });
-  },
+        });
+    },
 
-  closeClient: function(client) {
-    return new Promise((resolve, reject) => {
-      client.shutdown()
+    closeClient: function(client) {
+        return new Promise((resolve, reject) => {
+            client.shutdown()
         .then(() => {
-          resolve();
+            resolve();
         })
         .catch((err) => {
           //console.error('There was an error shutting down the client');
-          reject(err);
+            reject(err);
         });
-    });
-  }
-}
+        });
+    }
+};

--- a/src/connectors/CassandraConnector.js
+++ b/src/connectors/CassandraConnector.js
@@ -2,6 +2,13 @@
 
 const cassandra = require('cassandra-driver');
 
+const CASSANDRA_CONTACT_POINTS = ['1.2.3.4']; //TODO: get from env var
+
+const options = {
+  contactPoints: CASSANDRA_CONTACT_POINTS
+
+};
+
 module.exports = {
   getClient: function (contactPoints, keyspace) {
     const client = new cassandra.Client({ contactPoints: contactPoints, keyspace: keyspace }); //http://docs.datastax.com/en/developer/nodejs-driver/3.2/api/type.ClientOptions/

--- a/src/connectors/CassandraConnector.js
+++ b/src/connectors/CassandraConnector.js
@@ -5,7 +5,7 @@ const cassandra = require('cassandra-driver');
 const CASSANDRA_CONTACT_POINTS = ['1.2.3.4']; //TODO: get from env var
 
 const options = {
-  contactPoints: CASSANDRA_CONTACT_POINTS
+  contactPoints:CASSANDRA_CONTACT_POINTS
 
 };
 

--- a/src/connectors/CassandraConnector.js
+++ b/src/connectors/CassandraConnector.js
@@ -25,7 +25,7 @@ module.exports = {
         .catch((err) => {
           //console.error('There was an error when connecting to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys, err);
             client.shutdown();
-            reject(null);
+            reject(err);
         });
         });
     },

--- a/src/connectors/CassandraConnector.js
+++ b/src/connectors/CassandraConnector.js
@@ -12,34 +12,26 @@ const options = {
 
 module.exports = {
 
-  openClient: function () {
+  openClient: () => {
     const client = new cassandra.Client(options);
 
     return new Promise((resolve, reject) => {
       client.connect()
         .then(() => {
-          //console.log('Connected to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys);
-          //console.log('Keyspaces: %j', Object.keys(client.metadata.keyspaces));
           resolve(client);
         })
         .catch((err) => {
-          //console.error('There was an error when connecting to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys, err);
           client.shutdown();
           reject(err);
         });
     });
   },
 
-  closeClient: function(client) {
+  closeClient: client => {
     return new Promise((resolve, reject) => {
       client.shutdown()
-        .then(() => {
-          resolve();
-        })
-        .catch((err) => {
-          //console.error('There was an error shutting down the client');
-          reject(err);
-        });
+        .then(resolve)
+        .catch(reject);
     });
   }
 };

--- a/src/connectors/CassandraConnector.js
+++ b/src/connectors/CassandraConnector.js
@@ -17,8 +17,6 @@ module.exports = {
 Add app insights for reporting errors:
 Connecting to cassandra
 Failed storage mutations
-
-unit test with mocha and sinon
 */
 
 //let appInsights = require("applicationinsights");

--- a/src/osmClients/TileServiceManager.js
+++ b/src/osmClients/TileServiceManager.js
@@ -57,6 +57,7 @@ function InvokeServiceRequest(url, callback, featureCollection, bboxPolygon){
                 body.features.forEach(feature => {
                     const featureType = feature.properties.kind;
                     const coordinates = feature.geometry.coordinates;
+
                     if(featureType && PointFeatureInsideBBox(coordinates, bboxPolygon)
                                                && VALID_PLACE_KINDS.indexOf(featureType) > -1){
                         const population = feature.properties.population;
@@ -73,6 +74,7 @@ function InvokeServiceRequest(url, callback, featureCollection, bboxPolygon){
 
                         if(id && placeName && feature.geometry.type === 'Point'){
                             featureCollection.set(placeName, Object.assign({}, {
+
                                 coordinates: coordinates, id: id, source: feature.properties.source,
                                 name: placeName, name_ur: placeNameUr, name_id: placeNameId, name_ar: placeNameAr, name_de: placeNameDe, kind: feature.properties.kind,
                                 population: population, tileId: `${tileZ}_${tileY}_${tileX}`

--- a/src/osmClients/TileServiceManager.js
+++ b/src/osmClients/TileServiceManager.js
@@ -14,116 +14,116 @@ const TILE_SERVICE = 'http://tile.mapzen.com/mapzen/vector/v1/places';
 const VALID_PLACE_KINDS = ['neighbourhood', 'hamlet', 'suburb', 'locality', 'town', 'village', 'city', 'county', 'district', 'Populated place'];
 
 const FetchSiteDefintion = (siteId, callback) => {
-    let siteDefinition = memoryStore.get(siteId);
-    if(siteDefinition){
-        return callback(undefined, siteDefinition);
-    }else{
-        azureTableService.GetSiteDefinition(siteId, (error, siteList) => {
-            if(!error && siteList && siteList.length > 0){
-                siteDefinition = siteList[0].properties;
-                memoryStore.set(siteId, siteDefinition);
-                callback(undefined, siteDefinition);
-            }else{
-                const errorMsg = `There was an [${error}] error retreiving the site definition for site [${siteId}]`;
-                console.error(errorMsg);
-                callback(errorMsg, undefined);
-            }
-        });
-    }
+  let siteDefinition = memoryStore.get(siteId);
+  if(siteDefinition){
+    return callback(undefined, siteDefinition);
+  }else{
+    azureTableService.GetSiteDefinition(siteId, (error, siteList) => {
+      if(!error && siteList && siteList.length > 0){
+        siteDefinition = siteList[0].properties;
+        memoryStore.set(siteId, siteDefinition);
+        callback(undefined, siteDefinition);
+      }else{
+        const errorMsg = `There was an [${error}] error retreiving the site definition for site [${siteId}]`;
+        console.error(errorMsg);
+        callback(errorMsg, undefined);
+      }
+    });
+  }
 };
 
 function PointFeatureInsideBBox(coordinatePair, bboxPolygon){
-    const pointGeoJson = {
-        'type': 'Feature',
-        'geometry': {
-            'type': 'Point',
-            'coordinates': coordinatePair
-        }
-    };
+  const pointGeoJson = {
+    'type': 'Feature',
+    'geometry': {
+      'type': 'Point',
+      'coordinates': coordinatePair
+    }
+  };
 
-    return turfInside(pointGeoJson, bboxPolygon);
+  return turfInside(pointGeoJson, bboxPolygon);
 }
 
 function InvokeServiceRequest(url, callback, featureCollection, bboxPolygon){
-    const GET = {
-        url: url,
-        json: true,
-        withCredentials: false
-    };
+  const GET = {
+    url: url,
+    json: true,
+    withCredentials: false
+  };
 
-    request(GET, (error, response, body) => {
-        if(!error && response.statusCode === 200 && body) {
-            if(body.features && Array.isArray(body.features)){
-                body.features.forEach(feature => {
-                    const featureType = feature.properties.kind;
-                    const coordinates = feature.geometry.coordinates;
+  request(GET, (error, response, body) => {
+    if(!error && response.statusCode === 200 && body) {
+      if(body.features && Array.isArray(body.features)){
+        body.features.forEach(feature => {
+          const featureType = feature.properties.kind;
+          const coordinates = feature.geometry.coordinates;
 
-                    if(featureType && PointFeatureInsideBBox(coordinates, bboxPolygon)
+          if(featureType && PointFeatureInsideBBox(coordinates, bboxPolygon)
                                                && VALID_PLACE_KINDS.indexOf(featureType) > -1){
-                        const population = feature.properties.population;
-                        const placeName = feature.properties['name:en'] || feature.properties.name;
-                        const placeNameAr = feature.properties['name:ar'] || placeName;
-                        const placeNameUr = feature.properties['name:ur'] || placeName;
-                        const placeNameId = feature.properties['name:id'] || placeName;
-                        const placeNameDe = feature.properties['name:de'] || placeName;
-                        const id = feature.properties.id;
-                        const urlPart = url.split('/');
-                        const tileZ = urlPart[5];
-                        const tileX = urlPart[6];
-                        const tileY = urlPart[7].split('.')[0];
+            const population = feature.properties.population;
+            const placeName = feature.properties['name:en'] || feature.properties.name;
+            const placeNameAr = feature.properties['name:ar'] || placeName;
+            const placeNameUr = feature.properties['name:ur'] || placeName;
+            const placeNameId = feature.properties['name:id'] || placeName;
+            const placeNameDe = feature.properties['name:de'] || placeName;
+            const id = feature.properties.id;
+            const urlPart = url.split('/');
+            const tileZ = urlPart[5];
+            const tileX = urlPart[6];
+            const tileY = urlPart[7].split('.')[0];
 
-                        if(id && placeName && feature.geometry.type === 'Point'){
-                            featureCollection.set(placeName, Object.assign({}, {
+            if(id && placeName && feature.geometry.type === 'Point'){
+              featureCollection.set(placeName, Object.assign({}, {
 
-                                coordinates: coordinates, id: id, source: feature.properties.source,
-                                name: placeName, name_ur: placeNameUr, name_id: placeNameId, name_ar: placeNameAr, name_de: placeNameDe, kind: feature.properties.kind,
-                                population: population, tileId: `${tileZ}_${tileY}_${tileX}`
-                            }));
-                        }
-                    }
-                });
+                coordinates: coordinates, id: id, source: feature.properties.source,
+                name: placeName, name_ur: placeNameUr, name_id: placeNameId, name_ar: placeNameAr, name_de: placeNameDe, kind: feature.properties.kind,
+                population: population, tileId: `${tileZ}_${tileY}_${tileX}`
+              }));
             }
-        }else{
-            const errMsg = `[${error}] occured while fetching request for url ${url}`;
-            console.error(errMsg);
-            callback(errMsg);
+          }
+        });
+      }
+    }else{
+      const errMsg = `[${error}] occured while fetching request for url ${url}`;
+      console.error(errMsg);
+      callback(errMsg);
 
-            return;
-        }
+      return;
+    }
 
-        callback();
-    });
+    callback();
+  });
 }
 
 module.exports = {
-    FetchTilesInsideBbox: function(siteId, bbox, zoomLevel, minPopulation, maxPopulation, callback){
-        if(siteId && bbox && bbox.length === 4){
-            FetchSiteDefintion(siteId, (error, siteDefinition) => {
-                if(!error){
-                    const mapzenApiKey = siteDefinition.mapzenApiKey;
-                    const tileBbox = {north:bbox[3], west: bbox[0], east: bbox[2], south: bbox[1]};
-                    const tileIds = geotile.tileIdsForBoundingBox(tileBbox, zoomLevel);
-                    const bboxPolygon = turfBbox(bbox);
-                    const serviceCalls = tileIds.map(tileId => {
-                        const tilePart = tileId.split('_');
+  FetchTilesInsideBbox: function(siteId, bbox, zoomLevel, minPopulation, maxPopulation, callback){
+    if(siteId && bbox && bbox.length === 4){
+      FetchSiteDefintion(siteId, (error, siteDefinition) => {
+        if(!error){
+          const mapzenApiKey = siteDefinition.mapzenApiKey;
+          const tileBbox = {north:bbox[3], west: bbox[0], east: bbox[2], south: bbox[1]};
+          const tileIds = geotile.tileIdsForBoundingBox(tileBbox, zoomLevel);
+          const bboxPolygon = turfBbox(bbox);
+          const serviceCalls = tileIds.map(tileId => {
+            const tilePart = tileId.split('_');
 
-                        return `${TILE_SERVICE}/${tilePart[0]}/${tilePart[2]}/${tilePart[1]}.json?api_key=${mapzenApiKey}`;
-                    });
+            return `${TILE_SERVICE}/${tilePart[0]}/${tilePart[2]}/${tilePart[1]}.json?api_key=${mapzenApiKey}`;
+          });
 
-                    let featureCollection = new Map();
+          let featureCollection = new Map();
 
-                    async.eachLimit(serviceCalls, PARALLELISM_LIMIT, (serviceCall, cb) => InvokeServiceRequest(serviceCall, cb, featureCollection, bboxPolygon), err=> {
+          async.eachLimit(serviceCalls, PARALLELISM_LIMIT, (serviceCall, cb) => InvokeServiceRequest(serviceCall, cb, featureCollection, bboxPolygon), err=> {
 
-                        callback(err, Array.from(featureCollection.values()));
-                    });
-                }else{
-                    callback(error, undefined);
-                }
-            });
+            callback(err, Array.from(featureCollection.values()));
+          });
         }else{
-            const errMsg = 'invalid parameters';
-
-            callback(errMsg, undefined);
+          callback(error, undefined);
         }
+      });
+    }else{
+      const errMsg = 'invalid parameters';
+
+      callback(errMsg, undefined);
     }
+  }
 };

--- a/src/postgresClients/PostgresLocationManager.js
+++ b/src/postgresClients/PostgresLocationManager.js
@@ -16,119 +16,119 @@ const MIN_SEARCH_TERM_LENGTH = 4;
 const ENGLISH_LANG_CODE = 'en';
 
 const FetchSiteDefintion = (siteId, callback) => {
-    let siteDefinition = memoryStore.get(siteId);
-    if(siteDefinition){
-        return callback(undefined, siteDefinition);
-    }else{
-        console.log(`Looking up site code for site [${siteId}]`);
-        azureTableService.GetSiteDefinition(siteId, (error, siteList) => {
-            if(!error && siteList && siteList.length > 0){
-                siteDefinition = siteList[0].properties;
-                memoryStore.set(siteId, siteDefinition);
-                callback(undefined, siteDefinition);
-            }else{
-                const errorMsg = `There was an [${error}] error retreiving the site definition for site [${siteId}]`;
-                console.error(errorMsg);
-                callback(errorMsg, undefined);
-            }
-        });
-    }
+  let siteDefinition = memoryStore.get(siteId);
+  if(siteDefinition){
+    return callback(undefined, siteDefinition);
+  }else{
+    console.log(`Looking up site code for site [${siteId}]`);
+    azureTableService.GetSiteDefinition(siteId, (error, siteList) => {
+      if(!error && siteList && siteList.length > 0){
+        siteDefinition = siteList[0].properties;
+        memoryStore.set(siteId, siteDefinition);
+        callback(undefined, siteDefinition);
+      }else{
+        const errorMsg = `There was an [${error}] error retreiving the site definition for site [${siteId}]`;
+        console.error(errorMsg);
+        callback(errorMsg, undefined);
+      }
+    });
+  }
 };
 
 const WritePostgresRecord = (stmt, client, callback) => {
-    let successful = false;
-    let attempts = 0;
+  let successful = false;
+  let attempts = 0;
 
-    async.whilst(
+  async.whilst(
         () => {
-            return !successful && attempts < MAX_RETRIES;
+          return !successful && attempts < MAX_RETRIES;
         },
         pgCallback => {
             //console.log(stmt);
-            client.query(stmt, (pgErr, results) => { // eslint-disable-line no-unused-vars
-                attempts++;
+          client.query(stmt, (pgErr, results) => { // eslint-disable-line no-unused-vars
+            attempts++;
 
-                if (!pgErr){
-                    successful = true;
-                }else{
-                    let errMsg = `error[${pgErr}] occurred writing the stmt to postgres`;
-                    console.error(errMsg);
-                }
+            if (!pgErr){
+              successful = true;
+            }else{
+              let errMsg = `error[${pgErr}] occurred writing the stmt to postgres`;
+              console.error(errMsg);
+            }
 
-                return pgCallback();
-            });
+            return pgCallback();
+          });
         },
         callback
     );
 };
 
 const PostgresStmtBatch = (stmtList, siteId, callback) => {
-    FetchSiteDefintion(siteId, (error, siteDefinition) => {
-        if(!error && stmtList && stmtList.length > 0){
-            const postgresClient = new pg.Client(siteDefinition.featuresConnectionString);
-            postgresClient.connect(err => {
-                console.log(`processing ${stmtList.length} record write operations`);
-                if(!err){
-                    async.eachLimit(stmtList, PUSH_PARALLELISM, (stmt, cb)=>WritePostgresRecord(stmt, postgresClient, cb), err=>callback(siteDefinition.supportedLanguages, postgresClient, err));    
-                }else{
-                    const errMsg = 'An error occured obtaining a postgres connection';
-                    callback(siteDefinition.supportedLanguages, postgresClient, errMsg);
-                }
-            });
+  FetchSiteDefintion(siteId, (error, siteDefinition) => {
+    if(!error && stmtList && stmtList.length > 0){
+      const postgresClient = new pg.Client(siteDefinition.featuresConnectionString);
+      postgresClient.connect(err => {
+        console.log(`processing ${stmtList.length} record write operations`);
+        if(!err){
+          async.eachLimit(stmtList, PUSH_PARALLELISM, (stmt, cb)=>WritePostgresRecord(stmt, postgresClient, cb), err=>callback(siteDefinition.supportedLanguages, postgresClient, err));    
         }else{
-            const errMsg = `An error occured looking up the postgres connection string for site [${siteId}]`;
-            console.error(errMsg);
-            callback(undefined, undefined, errMsg);
+          const errMsg = 'An error occured obtaining a postgres connection';
+          callback(siteDefinition.supportedLanguages, postgresClient, errMsg);
         }
-    });
+      });
+    }else{
+      const errMsg = `An error occured looking up the postgres connection string for site [${siteId}]`;
+      console.error(errMsg);
+      callback(undefined, undefined, errMsg);
+    }
+  });
 };
 
 function QueryLocalities(languages, pgClient, callback){
-    const nameFieldNames = languages.map(lang => lang !== ENGLISH_LANG_CODE? `${lang}_name` : 'name');
-    const query =  `select ${nameFieldNames}, population, region, alternatenames, aciiname, country_iso, originalsource, geonameid as rowkey, ST_X(geog::geometry) as longitude, ST_Y(geog::geometry) as latitude from localities order by name ASC`;
+  const nameFieldNames = languages.map(lang => lang !== ENGLISH_LANG_CODE? `${lang}_name` : 'name');
+  const query =  `select ${nameFieldNames}, population, region, alternatenames, aciiname, country_iso, originalsource, geonameid as rowkey, ST_X(geog::geometry) as longitude, ST_Y(geog::geometry) as latitude from localities order by name ASC`;
 
-    pgClient.query(query, (error, results) => {
-        if(!error){
-            const locationsResponse = results.rows.map(location => {
-                let mutatedLocation = {
-                    'type': 'Location',
-                    'name': location.name.toLowerCase(),
-                    'name_ar': location.ar_name ? location.ar_name.toLowerCase() : '',
-                    'name_ur': location.ur_name ? location.ur_name.toLowerCase() : '',
-                    'name_id': location.id_name ? location.id_name.toLowerCase() : '',
-                    'name_de': location.de_name ? location.de_name.toLowerCase() : '',
-                    'coordinates': [location.longitude, location.latitude],
-                    'population': location.population,
-                    'alternatenames': location.alternatenames,
-                    'country_iso': location.country_iso,
-                    'aciiname': location.aciiname,
-                    'originalsource': location.originalsource,
-                    'region': location.region || '',
-                    'RowKey': location.rowkey.toString()
-                };
+  pgClient.query(query, (error, results) => {
+    if(!error){
+      const locationsResponse = results.rows.map(location => {
+        let mutatedLocation = {
+          'type': 'Location',
+          'name': location.name.toLowerCase(),
+          'name_ar': location.ar_name ? location.ar_name.toLowerCase() : '',
+          'name_ur': location.ur_name ? location.ur_name.toLowerCase() : '',
+          'name_id': location.id_name ? location.id_name.toLowerCase() : '',
+          'name_de': location.de_name ? location.de_name.toLowerCase() : '',
+          'coordinates': [location.longitude, location.latitude],
+          'population': location.population,
+          'alternatenames': location.alternatenames,
+          'country_iso': location.country_iso,
+          'aciiname': location.aciiname,
+          'originalsource': location.originalsource,
+          'region': location.region || '',
+          'RowKey': location.rowkey.toString()
+        };
                     
-                nameFieldNames.forEach(nameFieldName => {
-                    mutatedLocation[nameFieldName] = location[nameFieldName];
-                });
+        nameFieldNames.forEach(nameFieldName => {
+          mutatedLocation[nameFieldName] = location[nameFieldName];
+        });
               
-                return mutatedLocation;
-            });
+        return mutatedLocation;
+      });
 
-            pgClient.end();
-            callback(null, locationsResponse);
-        }else{
-            pgClient.end();
-            callback(`response for locations request returned error [${error}]`, undefined);
-        }
-    });
+      pgClient.end();
+      callback(null, locationsResponse);
+    }else{
+      pgClient.end();
+      callback(`response for locations request returned error [${error}]`, undefined);
+    }
+  });
 }
 
 function FetchPopularTerms(site, additionalEdge, limit, fromDate, toDate, zoomLevel, layertype, sourceFilter, callback){
-    if(fromDate && toDate){
-        let query;
+  if(fromDate && toDate){
+    let query;
 
-        if(additionalEdge){
-            query = `SELECT * FROM
+    if(additionalEdge){
+      query = `SELECT * FROM
                             (SELECT keyword, sum(mentions) as mentions, CASE WHEN keyword IN('${additionalEdge}') THEN 1 ELSE 0 END as defaultOrder
                              FROM tiles
                              WHERE mentions > 0 and zoom = ${zoomLevel}
@@ -139,8 +139,8 @@ function FetchPopularTerms(site, additionalEdge, limit, fromDate, toDate, zoomLe
                             ) a
                           ORDER BY defaultOrder DESC, mentions desc
                           LIMIT ${limit + 1}`;
-        }else{
-            query = `SELECT keyword, sum(mentions) as mentions
+    }else{
+      query = `SELECT keyword, sum(mentions) as mentions
                           FROM tiles
                           WHERE mentions > 0 and zoom = ${zoomLevel}
                                and periodtype='hour' and perioddate between '${fromDate}' and '${toDate}'
@@ -149,42 +149,42 @@ function FetchPopularTerms(site, additionalEdge, limit, fromDate, toDate, zoomLe
                              GROUP BY keyword
                           ORDER BY mentions desc
                           LIMIT ${limit}`;               
-        }
-
-        console.log(query);
-        FetchSiteDefintion(site, (error, siteDefinition) => {
-            if(!error){
-                PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                    if(!error){
-
-                        let response = {
-                            'edges': results.rows.map(item => Object.assign({}, {
-                                'name': item.keyword,
-                                'mentions': parseInt(item.mentions)
-                            }))
-                        };
-
-                        callback(null, response, siteDefinition.featuresConnectionString);
-                    }else{
-                        callback(`response for popular terms returned error [${error}]`, undefined, undefined);
-                    }
-                });
-            }
-        });
     }
+
+    console.log(query);
+    FetchSiteDefintion(site, (error, siteDefinition) => {
+      if(!error){
+        PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+          if(!error){
+
+            let response = {
+              'edges': results.rows.map(item => Object.assign({}, {
+                'name': item.keyword,
+                'mentions': parseInt(item.mentions)
+              }))
+            };
+
+            callback(null, response, siteDefinition.featuresConnectionString);
+          }else{
+            callback(`response for popular terms returned error [${error}]`, undefined, undefined);
+          }
+        });
+      }
+    });
+  }
 }
 
 function TilesFetchInnerQueryUnfiltered(keyword, selectClause, whereClause){
-    let innerQuery = `SELECT ${selectClause}, layer
+  let innerQuery = `SELECT ${selectClause}, layer
                             FROM tiles
                             WHERE ${whereClause}
                                 AND keyword = '${keyword}' and layer = 'none'`;
 
-    return innerQuery;
+  return innerQuery;
 }
 
 function TilesFetchInnerQueryWithFilters(keyword, selectClause, whereClause, filteredEdges){
-    let innerQuery = `SELECT ${selectClause}, layer as edge
+  let innerQuery = `SELECT ${selectClause}, layer as edge
                       FROM tiles
                       WHERE ${whereClause}
                          AND keyword = '${keyword}'
@@ -196,17 +196,17 @@ function TilesFetchInnerQueryWithFilters(keyword, selectClause, whereClause, fil
                           AND layer = '${keyword}' 
                           AND keyword IN('${filteredEdges.join('\',\'')}')`;
 
-    return innerQuery;
+  return innerQuery;
 }
 
 module.exports = {
-    FetchSentences: function(site, originalSource, bbox, locationCoords, mainTerm, fromDate, ToDate, limit, offset, filteredEdges,
+  FetchSentences: function(site, originalSource, bbox, locationCoords, mainTerm, fromDate, ToDate, limit, offset, filteredEdges,
                              language, sourceFilter, fulltextTerm, callback){
-        let offsetValue = offset || DEFAULT_OFFSET;
-        let limitValue = limit || DEFAULT_LIMIT;
-        let radiusDistance = 3000;
+    let offsetValue = offset || DEFAULT_OFFSET;
+    let limitValue = limit || DEFAULT_LIMIT;
+    let radiusDistance = 3000;
 
-        let query = ` SELECT st_asgeojson(geog) as featurecollection, array_to_json(keywords) as edges, array_to_json(original_sources) as original_sources_json,
+    let query = ` SELECT st_asgeojson(geog) as featurecollection, array_to_json(keywords) as edges, array_to_json(original_sources) as original_sources_json,
                              to_char(createdtime, 'MM/DD/YYYY HH:MI:SS AM') as createdtime_fmt, *
                       FROM tilemessages
                       WHERE createdtime <= '${ToDate}' and createdtime >= '${fromDate}'
@@ -221,85 +221,85 @@ module.exports = {
                         LIMIT ${limitValue} OFFSET ${offsetValue}
                     ;`;
 
-        console.log(query);
-        FetchSiteDefintion(site, (error, siteDefinition) => {
-            if(!error){
-                PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                    if(!error){
-                        let sentencesResponse = {
-                            'type': 'FeatureCollection',
-                            'bbox': bbox,
-                            'features': results.rows.map(item => Object.assign({}, JSON.parse(item.featurecollection), {
-                                'properties': {
-                                    'messageid':item.messageid,
-                                    'source':item.source,
-                                    'edges': item.edges,
-                                    'sentence': item[language+'_sentence']  || item[item.orig_language+'_sentence'],
-                                    'language': item[language+'_sentence'] ? language : item.orig_language,
-                                    'orig_language': item.orig_language,
-                                    'sentiment': item.neg_sentiment,
-                                    'createdtime': item.createdtime_fmt,
-                                    'fullText': item.full_text && item.full_text !== '' ? item.full_text : item[language+'_sentence']  || item[item.orig_language+'_sentence'],
-                                    'properties': {
-                                        'title': item.title || '',
-                                        'link': item.link || '',
-                                        'originalSources': item.original_sources_json && Array.isArray(item.original_sources_json) ? item.original_sources_json : [item.source]
-                                    }
-                                }
-                            }))
-                        };
+    console.log(query);
+    FetchSiteDefintion(site, (error, siteDefinition) => {
+      if(!error){
+        PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+          if(!error){
+            let sentencesResponse = {
+              'type': 'FeatureCollection',
+              'bbox': bbox,
+              'features': results.rows.map(item => Object.assign({}, JSON.parse(item.featurecollection), {
+                'properties': {
+                  'messageid':item.messageid,
+                  'source':item.source,
+                  'edges': item.edges,
+                  'sentence': item[language+'_sentence']  || item[item.orig_language+'_sentence'],
+                  'language': item[language+'_sentence'] ? language : item.orig_language,
+                  'orig_language': item.orig_language,
+                  'sentiment': item.neg_sentiment,
+                  'createdtime': item.createdtime_fmt,
+                  'fullText': item.full_text && item.full_text !== '' ? item.full_text : item[language+'_sentence']  || item[item.orig_language+'_sentence'],
+                  'properties': {
+                    'title': item.title || '',
+                    'link': item.link || '',
+                    'originalSources': item.original_sources_json && Array.isArray(item.original_sources_json) ? item.original_sources_json : [item.source]
+                  }
+                }
+              }))
+            };
 
-                        callback(undefined, sentencesResponse);
-                    }else{
-                        callback(error, undefined);
-                    }
-                });
-            }
+            callback(undefined, sentencesResponse);
+          }else{
+            callback(error, undefined);
+          }
         });
-    },
+      }
+    });
+  },
 
-    FetchEvent: function(site, messageId, sources, langCode, callback){
-        let query = ` SELECT st_asgeojson(geog) as featurecollection, to_char(createdtime, 'MM/DD/YYYY HH:MI:SS AM') as createdtime_fmt,
+  FetchEvent: function(site, messageId, sources, langCode, callback){
+    let query = ` SELECT st_asgeojson(geog) as featurecollection, to_char(createdtime, 'MM/DD/YYYY HH:MI:SS AM') as createdtime_fmt,
                              array_to_json(keywords) as edges, array_to_json(original_sources) as original_sources_json, *
                       FROM tilemessages
                       WHERE messageid = '${messageId}' and source IN('${sources.join('\',\'')}')
                     ;`;
 
-        FetchSiteDefintion(site, (error, siteDefinition) => {
-            if(!error){
-                PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                    if(!error && results.rows.length > 0){
-                        const feature = results.rows[0];
-                        const eventResponse = Object.assign({}, JSON.parse(feature.featurecollection), {
-                            'properties': {
-                                'createdtime': feature.createdtime_fmt,
-                                'sentiment': feature.neg_sentiment,
-                                'messageid':feature.messageid,
-                                'source':feature.source,
-                                'edges': feature.edges,
-                                'sentence': feature[langCode+'_sentence'] ? feature[langCode+'_sentence'] : feature[feature.orig_language+'_sentence'],
-                                'language': feature[langCode+'_sentence'] ? langCode : feature.orig_language,
-                                'fullText': feature.full_text && feature.full_text !== '' ? feature.full_text : feature[feature.orig_language+'_sentence']  || feature[feature.orig_language+'_sentence'],
-                                'properties': {
-                                    'title': feature.title || '',
-                                    'link': feature.link || '',
-                                    'originalSources': feature.original_sources_json && Array.isArray(feature.original_sources_json) ? feature.original_sources_json : [feature.source]
-                                }
-                            }
-                        });
+    FetchSiteDefintion(site, (error, siteDefinition) => {
+      if(!error){
+        PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+          if(!error && results.rows.length > 0){
+            const feature = results.rows[0];
+            const eventResponse = Object.assign({}, JSON.parse(feature.featurecollection), {
+              'properties': {
+                'createdtime': feature.createdtime_fmt,
+                'sentiment': feature.neg_sentiment,
+                'messageid':feature.messageid,
+                'source':feature.source,
+                'edges': feature.edges,
+                'sentence': feature[langCode+'_sentence'] ? feature[langCode+'_sentence'] : feature[feature.orig_language+'_sentence'],
+                'language': feature[langCode+'_sentence'] ? langCode : feature.orig_language,
+                'fullText': feature.full_text && feature.full_text !== '' ? feature.full_text : feature[feature.orig_language+'_sentence']  || feature[feature.orig_language+'_sentence'],
+                'properties': {
+                  'title': feature.title || '',
+                  'link': feature.link || '',
+                  'originalSources': feature.original_sources_json && Array.isArray(feature.original_sources_json) ? feature.original_sources_json : [feature.source]
+                }
+              }
+            });
 
-                        callback(undefined, eventResponse);
-                    }else{
-                        callback(error, undefined);
-                    }
-                });
-            }
+            callback(undefined, eventResponse);
+          }else{
+            callback(error, undefined);
+          }
         });
-    },
+      }
+    });
+  },
 
-    FetchEdgesByTileIds: function(site, tileIds, timespan, layertype, sourceFilter, fromDate, toDate, callback){
-        if(tileIds && timespan && layertype && tileIds.length > 0){
-            let query = `SELECT SUM(mentions) as mentions, keyword as edge
+  FetchEdgesByTileIds: function(site, tileIds, timespan, layertype, sourceFilter, fromDate, toDate, callback){
+    if(tileIds && timespan && layertype && tileIds.length > 0){
+      let query = `SELECT SUM(mentions) as mentions, keyword as edge
                         FROM  tiles
                         WHERE mentions > 0 and layertype = '${layertype}'
                           ${fromDate && toDate ? ` AND perioddate between '${fromDate}' and '${toDate}' and periodtype='hour'` : ` and period = '${timespan}'`}
@@ -307,36 +307,36 @@ module.exports = {
                           ${sourceFilter && sourceFilter.length > 0 ? ` AND source IN('${sourceFilter.join('\',\'')}')` : ''}
                         GROUP BY keyword`;
 
-            console.log(query);
-            FetchSiteDefintion(site, (error, siteDefinition) => {
-                if(!error){
-                    PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                        if(!error){
-                            let response = {
-                                'edges': results.rows.map(item => {
-                                    return {
-                                        'type': 'Term',
-                                        'name': item.edge,
-                                        'mentionCount': item.mentions
-                                    };
-                                })
-                            };
+      console.log(query);
+      FetchSiteDefintion(site, (error, siteDefinition) => {
+        if(!error){
+          PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+            if(!error){
+              let response = {
+                'edges': results.rows.map(item => {
+                  return {
+                    'type': 'Term',
+                    'name': item.edge,
+                    'mentionCount': item.mentions
+                  };
+                })
+              };
 
-                            callback(undefined, response);
-                        }else{
-                            callback(error, undefined);
-                        }
-                    });
-                }
-            });
-        }else{
-            callback('Invalid parameters were passed to FetchTermEdges Service', undefined);
+              callback(undefined, response);
+            }else{
+              callback(error, undefined);
+            }
+          });
         }
-    },
+      });
+    }else{
+      callback('Invalid parameters were passed to FetchTermEdges Service', undefined);
+    }
+  },
 
-    FetchEdgesByTerm: function(site, bbox, zoomLevel, keyword, timespan, layertype, sourceFilter, fromDate, toDate, callback){
-        if(zoomLevel && keyword && timespan, bbox){
-            let query = `SELECT SUM(mentions) as mentions, edge
+  FetchEdgesByTerm: function(site, bbox, zoomLevel, keyword, timespan, layertype, sourceFilter, fromDate, toDate, callback){
+    if(zoomLevel && keyword && timespan, bbox){
+      let query = `SELECT SUM(mentions) as mentions, edge
                         FROM
                             (SELECT mentions, layer as edge
                             FROM tiles
@@ -355,36 +355,36 @@ module.exports = {
                             and zoom = ${zoomLevel} AND layer = '${keyword}' and keyword <> '${keyword}') a
                         GROUP BY edge`;
 
-            FetchSiteDefintion(site, (error, siteDefinition) => {
-                if(!error){
-                    PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                        if(!error){
-                            let response = {
-                                'edges': results.rows.map(item => {
-                                    return {
-                                        'type': 'Term',
-                                        'name': item.edge,
-                                        'mentionCount': item.mentions
-                                    };
-                                })
-                            };
+      FetchSiteDefintion(site, (error, siteDefinition) => {
+        if(!error){
+          PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+            if(!error){
+              let response = {
+                'edges': results.rows.map(item => {
+                  return {
+                    'type': 'Term',
+                    'name': item.edge,
+                    'mentionCount': item.mentions
+                  };
+                })
+              };
 
-                            callback(undefined, response);
-                        }else{
-                            callback(error, undefined);
-                        }
-                    });
-                }
-            });
-        }else{
-            callback('Invalid parameters were passed to FetchTermEdges Service', undefined);
+              callback(undefined, response);
+            }else{
+              callback(error, undefined);
+            }
+          });
         }
-    },
+      });
+    }else{
+      callback('Invalid parameters were passed to FetchTermEdges Service', undefined);
+    }
+  },
 
-    FetchTopSources: function (site, fromDate, toDate, limit, mainTerm, sourceFilter, callback) {
+  FetchTopSources: function (site, fromDate, toDate, limit, mainTerm, sourceFilter, callback) {
         //Removing these data sources as the original_sources was originally backfilled with these values when the field was introduced.
-        const invalidDataSources = ['{facebook-messages}', '{facebook-comments}', '{twitter}', '{acled}', '{tadaweb}'];
-        const query = ` select original_sources, count(*), source
+    const invalidDataSources = ['{facebook-messages}', '{facebook-comments}', '{twitter}', '{acled}', '{tadaweb}'];
+    const query = ` select original_sources, count(*), source
                         from tilemessages where original_sources not in('${invalidDataSources.join('\',\'')}') 
                             ${sourceFilter && sourceFilter.length > 0 ? ` and source IN('${sourceFilter.join('\',\'')}') ` : ''}
                             ${mainTerm && mainTerm.length > 0 ? ` and array['${mainTerm}'] && keywords`: ''}
@@ -393,168 +393,168 @@ module.exports = {
                         order by count DESC
                         limit ${limit};`;
 
-        console.log(query);
-        FetchSiteDefintion(site, (error, siteDefinition) => {
-            if (!error) {
-                PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                    if (!error) {
+    console.log(query);
+    FetchSiteDefintion(site, (error, siteDefinition) => {
+      if (!error) {
+        PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+          if (!error) {
 
-                        const topSourcesResponse = results.rows.map(topSource => {
-                            let topSourcesAnalytics = {
-                                'Name': topSource.original_sources.toString(),
-                                'Count': topSource.count,
-                                'Source' : topSource.source
-                            };
+            const topSourcesResponse = results.rows.map(topSource => {
+              let topSourcesAnalytics = {
+                'Name': topSource.original_sources.toString(),
+                'Count': topSource.count,
+                'Source' : topSource.source
+              };
 
-                            return topSourcesAnalytics;
-                        });
+              return topSourcesAnalytics;
+            });
 
-                        callback(null, topSourcesResponse);
-                    } else {
-                        console.log(`response for top sources request returned error [${error}]`);
-                        callback(`response for top sources request returned error [${error}]`, undefined);
-                    }
-                });
-            }
-            else {
-                callback('Invalid parameter data provided.', undefined);
-            }
+            callback(null, topSourcesResponse);
+          } else {
+            console.log(`response for top sources request returned error [${error}]`);
+            callback(`response for top sources request returned error [${error}]`, undefined);
+          }
         });
-    },
+      }
+      else {
+        callback('Invalid parameter data provided.', undefined);
+      }
+    });
+  },
 
-    FetchFacebookAnalytics: function (site, days, callback) {
-        const query = `select original_sources, count(*), max(createdtime) as datetimeoflastpost
+  FetchFacebookAnalytics: function (site, days, callback) {
+    const query = `select original_sources, count(*), max(createdtime) as datetimeoflastpost
 from tilemessages where source in('facebook-comments', 'facebook-messages') and original_sources not in('{facebook-messages}', '{facebook-comments}')
 and createdtime  between CURRENT_TIMESTAMP - '${days} day'::INTERVAL and CURRENT_TIMESTAMP
 group by original_sources;`;
 
-        FetchSiteDefintion(site, (error, siteDefinition) => {
-            if (!error) {
-                PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                    if (!error) {
+    FetchSiteDefintion(site, (error, siteDefinition) => {
+      if (!error) {
+        PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+          if (!error) {
 
-                        const analyticsResponse = results.rows.map(facebookPage => {
-                            let facebookPageAnalytics = {
-                                'Name': facebookPage.original_sources.toString(),
-                                'Count': facebookPage.count,
-                                'LastUpdated': facebookPage.datetimeoflastpost
-                            };
+            const analyticsResponse = results.rows.map(facebookPage => {
+              let facebookPageAnalytics = {
+                'Name': facebookPage.original_sources.toString(),
+                'Count': facebookPage.count,
+                'LastUpdated': facebookPage.datetimeoflastpost
+              };
 
-                            return facebookPageAnalytics;
-                        });
+              return facebookPageAnalytics;
+            });
 
-                        callback(null, analyticsResponse);
-                    } else {
-                        callback(`response for facebook page analytics request returned error [${error}]`, undefined);
-                    }
-                });
-            }
-            else {
-                callback('Invalid parameter data provided.', undefined);
-            }
+            callback(null, analyticsResponse);
+          } else {
+            callback(`response for facebook page analytics request returned error [${error}]`, undefined);
+          }
         });
-    },
+      }
+      else {
+        callback('Invalid parameter data provided.', undefined);
+      }
+    });
+  },
 
-    FetchMessageTopicList: function (site, sourceFilter, fromDate, toDate, callback) {
-        FetchSiteDefintion(site, (error, siteDefinition) => {
-            if (!error && fromDate && toDate) {
-                const query = `SELECT DISTINCT unnest(keywords) as topics
+  FetchMessageTopicList: function (site, sourceFilter, fromDate, toDate, callback) {
+    FetchSiteDefintion(site, (error, siteDefinition) => {
+      if (!error && fromDate && toDate) {
+        const query = `SELECT DISTINCT unnest(keywords) as topics
                        FROM tilemessages
                        WHERE createdtime <= '${toDate}' and createdtime >= '${fromDate}'
                             ${sourceFilter && sourceFilter.length > 0 ? ` AND source IN('${sourceFilter.join('\',\'')}')` : ''}`;
-                PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                    if (!error) {
-                        const topicsResponse = results.rows.map(row => Object.assign({}, {'type': 'Term', 'name': row.topics, 'RowKey': row.topics}));
-                        callback(null, topicsResponse);
-                    } else {
-                        callback(`response for facebook page analytics request returned error [${error}]`, undefined);
-                    }
-                });
-            }
-            else {
-                callback('Invalid parameter data provided.', undefined);
-            }
+        PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+          if (!error) {
+            const topicsResponse = results.rows.map(row => Object.assign({}, {'type': 'Term', 'name': row.topics, 'RowKey': row.topics}));
+            callback(null, topicsResponse);
+          } else {
+            callback(`response for facebook page analytics request returned error [${error}]`, undefined);
+          }
         });
-    },
+      }
+      else {
+        callback('Invalid parameter data provided.', undefined);
+      }
+    });
+  },
 
-    FetchTilesByBbox: function(site, bbox, zoomLevel, layerFilter, keyword, timespan, layertype, sourceFilter, fromDate, toDate, callback)
+  FetchTilesByBbox: function(site, bbox, zoomLevel, layerFilter, keyword, timespan, layertype, sourceFilter, fromDate, toDate, callback)
     {
-        let filteredEdges = layerFilter, unfiltered = false;
-        if(filteredEdges && Array.isArray(filteredEdges) && filteredEdges.length > 0){
-            filteredEdges = layerFilter.filter(term=>term !== keyword && term !== 'none');
-        }else{
-            unfiltered = true;
-        }
+    let filteredEdges = layerFilter, unfiltered = false;
+    if(filteredEdges && Array.isArray(filteredEdges) && filteredEdges.length > 0){
+      filteredEdges = layerFilter.filter(term=>term !== keyword && term !== 'none');
+    }else{
+      unfiltered = true;
+    }
 
-        if(timespan){
-            let whereClause = `mentions > 0 and layertype = '${layertype}'
+    if(timespan){
+      let whereClause = `mentions > 0 and layertype = '${layertype}'
                             ${fromDate && toDate ? ` AND perioddate between '${fromDate}' and '${toDate}' and periodtype='hour'` : ` and period = '${timespan}'`}
                             ${bbox ? ` and tiles.geog && ST_MakeEnvelope(${bbox.join(', ')}, 4326)` : ''}
                             ${sourceFilter && sourceFilter.length > 0 ? ` AND source IN('${sourceFilter.join('\',\'')}')` : ''}
                             ${zoomLevel ? ` and zoom = ${zoomLevel}` : ''}`;
-            let selectClause = 'geog, neg_sentiment, pos_sentiment, mentions, tileid';
-            let query, innerQuery, fromClause;
+      let selectClause = 'geog, neg_sentiment, pos_sentiment, mentions, tileid';
+      let query, innerQuery, fromClause;
 
-            if(unfiltered){
-                fromClause = TilesFetchInnerQueryUnfiltered(keyword, selectClause, whereClause);
-            }else{
-                fromClause = TilesFetchInnerQueryWithFilters(keyword, selectClause, whereClause, filteredEdges);
-            }
+      if(unfiltered){
+        fromClause = TilesFetchInnerQueryUnfiltered(keyword, selectClause, whereClause);
+      }else{
+        fromClause = TilesFetchInnerQueryWithFilters(keyword, selectClause, whereClause, filteredEdges);
+      }
 
-            fromClause = `SELECT features.geog, tileid, SUM(mentions*pos_sentiment) as pos_wavg, sum(mentions) as mentions,
+      fromClause = `SELECT features.geog, tileid, SUM(mentions*pos_sentiment) as pos_wavg, sum(mentions) as mentions,
 				                 SUM(mentions*neg_sentiment) as neg_wavg
                           FROM (${fromClause}) features
                           GROUP BY geog, tileid`;
 
-            innerQuery = `SELECT geog, tileid, neg_wavg/mentions AS neg_wavg,
+      innerQuery = `SELECT geog, tileid, neg_wavg/mentions AS neg_wavg,
                                 pos_wavg/mentions AS pos_wavg,
                                 mentions as mentions
                           FROM (${fromClause}) features_agg`;
 
-            query = `SELECT st_asgeojson(tiles.geog) as feature, tiles.*, population
+      query = `SELECT st_asgeojson(tiles.geog) as feature, tiles.*, population
                      FROM (SELECT (select l.name as location_name FROM localities as l ORDER BY a.geog <-> l.geog LIMIT 1), a.*
                            FROM (${innerQuery}) a) tiles, localities b
                      WHERE location_name = b.name`;
 
-            console.log(query);
+      console.log(query);
 
-            FetchSiteDefintion(site, (error, siteDefinition) => {
-                if(!error){
-                    PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                        if(!error){
-                            let tileResponse = {
-                                'type': 'FeatureCollection',
-                                'features': results.rows.map(item => Object.assign({}, JSON.parse(item.feature), {
-                                    'properties': {
-                                        'neg_sentiment':item.neg_sentiment || item.neg_wavg,
-                                        'pos_sentiment':item.pos_sentiment || item.pos_wavg,
-                                        'mentionCount': parseInt(item.mentions),
-                                        'population': item.population,
-                                        'location': item.location_name,
-                                        'tileId': item.tileid
-                                    }
-                                }))
-                            };
+      FetchSiteDefintion(site, (error, siteDefinition) => {
+        if(!error){
+          PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+            if(!error){
+              let tileResponse = {
+                'type': 'FeatureCollection',
+                'features': results.rows.map(item => Object.assign({}, JSON.parse(item.feature), {
+                  'properties': {
+                    'neg_sentiment':item.neg_sentiment || item.neg_wavg,
+                    'pos_sentiment':item.pos_sentiment || item.pos_wavg,
+                    'mentionCount': parseInt(item.mentions),
+                    'population': item.population,
+                    'location': item.location_name,
+                    'tileId': item.tileid
+                  }
+                }))
+              };
 
 
-                            callback(undefined, tileResponse);
-                        }else{
-                            callback(error, undefined);
-                        }
-                    });
-                }
-            });
-        }else{
-            callback('Invalid parameter data provided.', undefined);
+              callback(undefined, tileResponse);
+            }else{
+              callback(error, undefined);
+            }
+          });
         }
-    },
+      });
+    }else{
+      callback('Invalid parameter data provided.', undefined);
+    }
+  },
 
-    FetchTilesByIds: function(site, tileIds, edgeFilters, timespan, layertype, sourceFilter, fromDate, toDate, callback)
+  FetchTilesByIds: function(site, tileIds, edgeFilters, timespan, layertype, sourceFilter, fromDate, toDate, callback)
     {
-        if(timespan && tileIds && Array.isArray(tileIds) && tileIds.length > 0){
-            let query, innerQuery, fromClause;
+    if(timespan && tileIds && Array.isArray(tileIds) && tileIds.length > 0){
+      let query, innerQuery, fromClause;
 
-            fromClause = `SELECT geog, neg_sentiment, pos_sentiment, mentions, tileid, keyword as edge
+      fromClause = `SELECT geog, neg_sentiment, pos_sentiment, mentions, tileid, keyword as edge
 					      FROM tiles
 					      WHERE mentions > 0 and layertype = '${layertype}' and layer = 'none'
                             and tileid IN('${tileIds.join('\',\'')}')
@@ -562,57 +562,57 @@ group by original_sources;`;
                           ${sourceFilter && sourceFilter.length > 0 ? ` AND source IN('${sourceFilter.join('\',\'')}')` : ''}
                           ${edgeFilters.length === 0 ? ' and keyword is not null ': ` and keyword IN('${edgeFilters.join('\',\'')}')`}`;
 
-            fromClause = `SELECT features.geog, tileid, SUM(mentions*pos_sentiment) as pos_wavg, sum(mentions) as mentions,
+      fromClause = `SELECT features.geog, tileid, SUM(mentions*pos_sentiment) as pos_wavg, sum(mentions) as mentions,
 				                 SUM(mentions*neg_sentiment) as neg_wavg
                           FROM (${fromClause}) features
                           GROUP BY geog, tileid`;
 
-            innerQuery = `SELECT geog, tileid, neg_wavg/mentions AS neg_wavg,
+      innerQuery = `SELECT geog, tileid, neg_wavg/mentions AS neg_wavg,
                                 pos_wavg/mentions AS pos_wavg,
                                 mentions as mentions
                           FROM (${fromClause}) features_agg`;
 
-            query = `SELECT st_asgeojson(tiles.geog) as feature, population, tileId, location_name, neg_wavg, pos_wavg, mentions
+      query = `SELECT st_asgeojson(tiles.geog) as feature, population, tileId, location_name, neg_wavg, pos_wavg, mentions
                      FROM (SELECT (select l.name as location_name FROM localities as l ORDER BY a.geog <-> l.geog LIMIT 1), a.*
                            FROM (${innerQuery}) a) tiles, localities b
                      WHERE location_name = b.name`;
 
-            FetchSiteDefintion(site, (error, siteDefinition) => {
-                if(!error){
-                    PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                        if(!error){
-                            let tileResponse = {
-                                'type': 'FeatureCollection',
-                                'features': results.rows.map(item => Object.assign({}, JSON.parse(item.feature), {
-                                    'properties': {
-                                        'neg_sentiment':item.neg_sentiment || item.neg_wavg,
-                                        'pos_sentiment':item.pos_sentiment || item.pos_wavg,
-                                        'mentionCount': parseInt(item.mentions),
-                                        'population': item.population,
-                                        'location': item.location_name,
-                                        'tileId': item.tileid
-                                    }
-                                }))
-                            };
+      FetchSiteDefintion(site, (error, siteDefinition) => {
+        if(!error){
+          PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+            if(!error){
+              let tileResponse = {
+                'type': 'FeatureCollection',
+                'features': results.rows.map(item => Object.assign({}, JSON.parse(item.feature), {
+                  'properties': {
+                    'neg_sentiment':item.neg_sentiment || item.neg_wavg,
+                    'pos_sentiment':item.pos_sentiment || item.pos_wavg,
+                    'mentionCount': parseInt(item.mentions),
+                    'population': item.population,
+                    'location': item.location_name,
+                    'tileId': item.tileid
+                  }
+                }))
+              };
 
 
-                            callback(undefined, tileResponse);
-                        }else{
-                            callback(error, undefined);
-                        }
-                    });
-                }
-            });
-        }else{
-            callback('Invalid parameter data provided.', undefined);
+              callback(undefined, tileResponse);
+            }else{
+              callback(error, undefined);
+            }
+          });
         }
-    },
+      });
+    }else{
+      callback('Invalid parameter data provided.', undefined);
+    }
+  },
 
-    FetchPopularLocations: function(site, langCode, limit, timespan, zoomLevel, layertype, sourceFilter, fromDate, toDate, callback){
-        if(langCode && timespan){
-            let nameFieldName = langCode !== ENGLISH_LANG_CODE ? `${langCode}_name` : 'name';
+  FetchPopularLocations: function(site, langCode, limit, timespan, zoomLevel, layertype, sourceFilter, fromDate, toDate, callback){
+    if(langCode && timespan){
+      let nameFieldName = langCode !== ENGLISH_LANG_CODE ? `${langCode}_name` : 'name';
 
-            let query = `SELECT  location_name, SUM(mentions) as mentions, ST_X(b.geog::geometry) as longitude, ST_Y(b.geog::geometry) as latitude, population
+      let query = `SELECT  location_name, SUM(mentions) as mentions, ST_X(b.geog::geometry) as longitude, ST_Y(b.geog::geometry) as latitude, population
                          FROM
                             (SELECT (select l.${nameFieldName} as location_name FROM localities as l ORDER BY a.geog <-> l.geog LIMIT 1), a.*
                             FROM   (SELECT geog, tileid, sum(mentions) as mentions
@@ -627,54 +627,54 @@ group by original_sources;`;
                          GROUP BY location_name, b.geog, population
                          ORDER BY mentions desc
                          LIMIT ${limit}`;
-            console.log(query);
-            FetchSiteDefintion(site, (error, siteDefinition) => {
-                if(!error){
-                    PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
-                        if(!error){
-                            let locationsResponse = {
-                                'edges': results.rows.map(item => Object.assign({}, {
-                                    'name': item.location_name,
-                                    'population': item.population,
-                                    'coordinates': [item.longitude, item.latitude],
-                                    'mentions': item.mentions
-                                }))
-                            };
+      console.log(query);
+      FetchSiteDefintion(site, (error, siteDefinition) => {
+        if(!error){
+          PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
+            if(!error){
+              let locationsResponse = {
+                'edges': results.rows.map(item => Object.assign({}, {
+                  'name': item.location_name,
+                  'population': item.population,
+                  'coordinates': [item.longitude, item.latitude],
+                  'mentions': item.mentions
+                }))
+              };
 
-                            callback(null, locationsResponse);
-                        }else{
-                            callback(`response for locations request returned error [${error}]`, undefined);
-                        }
-                    });
-                }
-            });
+              callback(null, locationsResponse);
+            }else{
+              callback(`response for locations request returned error [${error}]`, undefined);
+            }
+          });
         }
-    },
+      });
+    }
+  },
 
-    FetchAllLocations: function(siteCode, callback){
-        if(siteCode){
-            FetchSiteDefintion(siteCode, (error, siteDefinition) => {
-                if(!error){
-                    const postgresClient = new pg.Client(siteDefinition.featuresConnectionString);
-                    postgresClient.connect(err => {
-                        if(!err){
-                            QueryLocalities(siteDefinition.supportedLanguages, postgresClient, callback);
-                        }else{
-                            callback(error, undefined);
-                        }
-                    });
-                }else{
-                    const errMsg = `An error occured looking up the postgres connection for ${siteCode}`;
-                    console.error(errMsg);
-                    callback(errMsg, undefined);
-                }
-            });
+  FetchAllLocations: function(siteCode, callback){
+    if(siteCode){
+      FetchSiteDefintion(siteCode, (error, siteDefinition) => {
+        if(!error){
+          const postgresClient = new pg.Client(siteDefinition.featuresConnectionString);
+          postgresClient.connect(err => {
+            if(!err){
+              QueryLocalities(siteDefinition.supportedLanguages, postgresClient, callback);
+            }else{
+              callback(error, undefined);
+            }
+          });
+        }else{
+          const errMsg = `An error occured looking up the postgres connection for ${siteCode}`;
+          console.error(errMsg);
+          callback(errMsg, undefined);
         }
-    },
-    SaveLocalities: function(siteCode, modifiedLocations, callback){
-        if(siteCode){
-            const upsertStmts = modifiedLocations.map(location=>{
-                return `INSERT INTO localities (
+      });
+    }
+  },
+  SaveLocalities: function(siteCode, modifiedLocations, callback){
+    if(siteCode){
+      const upsertStmts = modifiedLocations.map(location=>{
+        return `INSERT INTO localities (
                             geonameid, originalsource, feature_class, name, region, alternatenames,
                             aciiname, country_iso, geog, adminid, population, ar_name, ur_name, id_name, de_name
                         ) VALUES (
@@ -708,43 +708,43 @@ group by original_sources;`;
                             de_name = '${location.name_de ? location.name_de.replace(/\'/g, '\'\'') : ''}',
                             geog = ST_SetSRID(ST_MakePoint(${location.coordinates[0]}, ${location.coordinates[1]}), 4326)
                         ;`;
-            });
+      });
 
-            console.log(`Processing request for a ${upsertStmts.length}`);
-            PostgresStmtBatch(upsertStmts, siteCode, (supportedLanguages, pgClient, error)=>{
-                if(!error){
-                    QueryLocalities(supportedLanguages, pgClient, callback);
-                }else{
-                    callback(error, undefined);
-                }
-            });
+      console.log(`Processing request for a ${upsertStmts.length}`);
+      PostgresStmtBatch(upsertStmts, siteCode, (supportedLanguages, pgClient, error)=>{
+        if(!error){
+          QueryLocalities(supportedLanguages, pgClient, callback);
+        }else{
+          callback(error, undefined);
         }
-    },
-    RemoveLocalities: function(siteCode, modifiedLocations, callback){
-        if(siteCode){
-            const geonameIds = modifiedLocations.map(location=>parseInt(location.RowKey));
-            const deleteStmt = `DELETE FROM localities where geonameid IN(${geonameIds.join(',')});`;
+      });
+    }
+  },
+  RemoveLocalities: function(siteCode, modifiedLocations, callback){
+    if(siteCode){
+      const geonameIds = modifiedLocations.map(location=>parseInt(location.RowKey));
+      const deleteStmt = `DELETE FROM localities where geonameid IN(${geonameIds.join(',')});`;
 
-            console.log(deleteStmt);
+      console.log(deleteStmt);
 
-            PostgresStmtBatch([deleteStmt], siteCode, (supportedLanguages, pgClient, error)=>{
-                if(!error){
-                    QueryLocalities(supportedLanguages, pgClient, callback);
-                }else{
-                    callback(error, undefined);
-                }
-            });
+      PostgresStmtBatch([deleteStmt], siteCode, (supportedLanguages, pgClient, error)=>{
+        if(!error){
+          QueryLocalities(supportedLanguages, pgClient, callback);
+        }else{
+          callback(error, undefined);
         }
-    },
-    EdgeTimeSeries: function(siteKey, limit, zoom, layertype, fromDate, toDate, selectedEdge, dataSource, callback){
-        if(siteKey){
-            FetchPopularTerms(siteKey, selectedEdge || undefined, limit, fromDate, toDate,
+      });
+    }
+  },
+  EdgeTimeSeries: function(siteKey, limit, zoom, layertype, fromDate, toDate, selectedEdge, dataSource, callback){
+    if(siteKey){
+      FetchPopularTerms(siteKey, selectedEdge || undefined, limit, fromDate, toDate,
                               zoom, layertype, dataSource, (error, popularTerms, featureConnString) => {
-                                  if(!error){
-                                      const labels = popularTerms.edges;
+                                if(!error){
+                                  const labels = popularTerms.edges;
 
-                                      if(labels && labels.length > 0){
-                                          const query = ` SELECT keyword, sum(mentions) as mentions, perioddate
+                                  if(labels && labels.length > 0){
+                                    const query = ` SELECT keyword, sum(mentions) as mentions, perioddate
                                         FROM tiles
                                         WHERE zoom = ${zoom} and keyword is not null and layer = 'none' and periodtype='hour'
                                             and perioddate between '${fromDate}' and '${toDate}'
@@ -753,33 +753,33 @@ group by original_sources;`;
                                         GROUP BY keyword, perioddate
                                         ORDER BY perioddate, keyword`;
 
-                                          PostgresService(featureConnString, query, (error, results) => {
-                                              if(!error){
-                                                  let aggregateMap = new Map();
-                                                  let timeSeriesEntry;
+                                    PostgresService(featureConnString, query, (error, results) => {
+                                      if(!error){
+                                        let aggregateMap = new Map();
+                                        let timeSeriesEntry;
 
-                                                  results.rows.forEach(item => {
-                                                      const unixTime = moment(item.perioddate).valueOf();
-                                                      timeSeriesEntry = aggregateMap.get(unixTime);
-                                                      if(!timeSeriesEntry){
-                                                          timeSeriesEntry = Object.assign({}, {date: new Date(unixTime), edges: [], mentions: []});
-                                                          aggregateMap.set(unixTime, timeSeriesEntry);
-                                                      }
+                                        results.rows.forEach(item => {
+                                          const unixTime = moment(item.perioddate).valueOf();
+                                          timeSeriesEntry = aggregateMap.get(unixTime);
+                                          if(!timeSeriesEntry){
+                                            timeSeriesEntry = Object.assign({}, {date: new Date(unixTime), edges: [], mentions: []});
+                                            aggregateMap.set(unixTime, timeSeriesEntry);
+                                          }
 
-                                                      timeSeriesEntry.edges.push(item.keyword);
-                                                      timeSeriesEntry.mentions.push(item.mentions);
-                                                  });
+                                          timeSeriesEntry.edges.push(item.keyword);
+                                          timeSeriesEntry.mentions.push(item.mentions);
+                                        });
 
-                                                  callback(null, {labels: labels, graphData: Array.from(aggregateMap.values())});
-                                              }else{
-                                                  callback(`response for locations request returned error [${error}]`, undefined);
-                                              }
-                                          });
+                                        callback(null, {labels: labels, graphData: Array.from(aggregateMap.values())});
                                       }else{
-                                          callback(null, {labels: [], graphData: []});
+                                        callback(`response for locations request returned error [${error}]`, undefined);
                                       }
+                                    });
+                                  }else{
+                                    callback(null, {labels: [], graphData: []});
                                   }
+                                }
                               });
-        }
     }
+  }
 };

--- a/src/postgresClients/PostgresLocationManager.js
+++ b/src/postgresClients/PostgresLocationManager.js
@@ -502,7 +502,7 @@ group by original_sources;`;
       }
 
       fromClause = `SELECT features.geog, tileid, SUM(mentions*pos_sentiment) as pos_wavg, sum(mentions) as mentions,
-				                 SUM(mentions*neg_sentiment) as neg_wavg
+                         SUM(mentions*neg_sentiment) as neg_wavg
                           FROM (${fromClause}) features
                           GROUP BY geog, tileid`;
 
@@ -555,15 +555,15 @@ group by original_sources;`;
       let query, innerQuery, fromClause;
 
       fromClause = `SELECT geog, neg_sentiment, pos_sentiment, mentions, tileid, keyword as edge
-					      FROM tiles
-					      WHERE mentions > 0 and layertype = '${layertype}' and layer = 'none'
+                FROM tiles
+                WHERE mentions > 0 and layertype = '${layertype}' and layer = 'none'
                             and tileid IN('${tileIds.join('\',\'')}')
                           ${fromDate && toDate ? ` AND perioddate between '${fromDate}' and '${toDate}' and periodtype='hour'` : ` and period = '${timespan}'`}
                           ${sourceFilter && sourceFilter.length > 0 ? ` AND source IN('${sourceFilter.join('\',\'')}')` : ''}
                           ${edgeFilters.length === 0 ? ' and keyword is not null ': ` and keyword IN('${edgeFilters.join('\',\'')}')`}`;
 
       fromClause = `SELECT features.geog, tileid, SUM(mentions*pos_sentiment) as pos_wavg, sum(mentions) as mentions,
-				                 SUM(mentions*neg_sentiment) as neg_wavg
+                         SUM(mentions*neg_sentiment) as neg_wavg
                           FROM (${fromClause}) features
                           GROUP BY geog, tileid`;
 

--- a/src/postgresClients/PostgresLocationManager.js
+++ b/src/postgresClients/PostgresLocationManager.js
@@ -69,7 +69,7 @@ const PostgresStmtBatch = (stmtList, siteId, callback) => {
             postgresClient.connect(err => {
                 console.log(`processing ${stmtList.length} record write operations`);
                 if(!err){
-                    async.eachLimit(stmtList, PUSH_PARALLELISM, (stmt, cb)=>WritePostgresRecord(stmt, postgresClient, cb), err=>callback(siteDefinition.supportedLanguages, postgresClient, err));
+                    async.eachLimit(stmtList, PUSH_PARALLELISM, (stmt, cb)=>WritePostgresRecord(stmt, postgresClient, cb), err=>callback(siteDefinition.supportedLanguages, postgresClient, err));    
                 }else{
                     const errMsg = 'An error occured obtaining a postgres connection';
                     callback(siteDefinition.supportedLanguages, postgresClient, errMsg);
@@ -106,11 +106,11 @@ function QueryLocalities(languages, pgClient, callback){
                     'region': location.region || '',
                     'RowKey': location.rowkey.toString()
                 };
-
+                    
                 nameFieldNames.forEach(nameFieldName => {
                     mutatedLocation[nameFieldName] = location[nameFieldName];
                 });
-
+              
                 return mutatedLocation;
             });
 
@@ -148,7 +148,7 @@ function FetchPopularTerms(site, additionalEdge, limit, fromDate, toDate, zoomLe
                                ${sourceFilter && sourceFilter.length > 0 ? ` AND source IN('${sourceFilter.join('\',\'')}')` : ''}
                              GROUP BY keyword
                           ORDER BY mentions desc
-                          LIMIT ${limit}`;
+                          LIMIT ${limit}`;               
         }
 
         console.log(query);
@@ -156,7 +156,6 @@ function FetchPopularTerms(site, additionalEdge, limit, fromDate, toDate, zoomLe
             if(!error){
                 PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
                     if(!error){
-
 
                         let response = {
                             'edges': results.rows.map(item => Object.assign({}, {
@@ -190,11 +189,11 @@ function TilesFetchInnerQueryWithFilters(keyword, selectClause, whereClause, fil
                       WHERE ${whereClause}
                          AND keyword = '${keyword}'
                          AND layer IN('${filteredEdges.join('\',\'')}')
-                      UNION
+                      UNION 
                       SELECT ${selectClause}, keyword as edge
                       FROM tiles
                       WHERE ${whereClause}
-                          AND layer = '${keyword}'
+                          AND layer = '${keyword}' 
                           AND keyword IN('${filteredEdges.join('\',\'')}')`;
 
     return innerQuery;
@@ -227,7 +226,6 @@ module.exports = {
             if(!error){
                 PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
                     if(!error){
-
                         let sentencesResponse = {
                             'type': 'FeatureCollection',
                             'bbox': bbox,
@@ -387,7 +385,7 @@ module.exports = {
         //Removing these data sources as the original_sources was originally backfilled with these values when the field was introduced.
         const invalidDataSources = ['{facebook-messages}', '{facebook-comments}', '{twitter}', '{acled}', '{tadaweb}'];
         const query = ` select original_sources, count(*), source
-                        from tilemessages where original_sources not in('${invalidDataSources.join('\',\'')}')
+                        from tilemessages where original_sources not in('${invalidDataSources.join('\',\'')}') 
                             ${sourceFilter && sourceFilter.length > 0 ? ` and source IN('${sourceFilter.join('\',\'')}') ` : ''}
                             ${mainTerm && mainTerm.length > 0 ? ` and array['${mainTerm}'] && keywords`: ''}
                             and createdtime <= '${toDate}' and createdtime >= '${fromDate}'
@@ -464,7 +462,6 @@ group by original_sources;`;
                        FROM tilemessages
                        WHERE createdtime <= '${toDate}' and createdtime >= '${fromDate}'
                             ${sourceFilter && sourceFilter.length > 0 ? ` AND source IN('${sourceFilter.join('\',\'')}')` : ''}`;
-
                 PostgresService(siteDefinition.featuresConnectionString, query, (error, results) => {
                     if (!error) {
                         const topicsResponse = results.rows.map(row => Object.assign({}, {'type': 'Term', 'name': row.topics, 'RowKey': row.topics}));
@@ -495,8 +492,6 @@ group by original_sources;`;
                             ${bbox ? ` and tiles.geog && ST_MakeEnvelope(${bbox.join(', ')}, 4326)` : ''}
                             ${sourceFilter && sourceFilter.length > 0 ? ` AND source IN('${sourceFilter.join('\',\'')}')` : ''}
                             ${zoomLevel ? ` and zoom = ${zoomLevel}` : ''}`;
-
-
             let selectClause = 'geog, neg_sentiment, pos_sentiment, mentions, tileid';
             let query, innerQuery, fromClause;
 
@@ -626,7 +621,7 @@ group by original_sources;`;
                                     ${fromDate && toDate ? ` AND perioddate between '${fromDate}' and '${toDate}' and periodtype='hour'` : ` and period = '${timespan}'`}
                                     and layertype = '${layertype}' and keyword is not null and layer = 'none'
                                     ${sourceFilter && sourceFilter.length > 0 ? ` AND source IN('${sourceFilter.join('\',\'')}')` : ''}
-                                GROUP BY geog, tileid) a) locations,
+                                GROUP BY geog, tileid) a) locations, 
                                 localities b
                          WHERE locations.location_name = b.name
                          GROUP BY location_name, b.geog, population

--- a/src/resolvers/Edges.js
+++ b/src/resolvers/Edges.js
@@ -10,192 +10,192 @@ const DEFAULT_LAYER_TYPE = 'associations';
 const DEFAULT_ZOOM_LEVEL = 15;
 
 module.exports = {
-    terms(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        let siteCode = args.site;
-        let fromDate = args.fromDate;
-        let sourceFilter = args.sourceFilter || ['tadaweb'];
-        let toDate = args.toDate;
+  terms(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    let siteCode = args.site;
+    let fromDate = args.fromDate;
+    let sourceFilter = args.sourceFilter || ['tadaweb'];
+    let toDate = args.toDate;
 
-        return new Promise((resolve, reject) => {
-            if(fromDate && toDate){
-                postgresMessageService.FetchMessageTopicList(siteCode, sourceFilter, fromDate, toDate,
+    return new Promise((resolve, reject) => {
+      if(fromDate && toDate){
+        postgresMessageService.FetchMessageTopicList(siteCode, sourceFilter, fromDate, toDate,
                         (error, result) => {
-                            if(error){
-                                let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                                reject(errorMsg);
-                            }else{
-                                resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Location'}));
-                            }
-                        });
-            }else{
-                azureTableService.GetKeywordList(siteCode,
-                        (error, result) => {
-                            if(error){
-                                let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                                reject(errorMsg);
-                            }else{
-                                resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Term'}));
-                            }
-                        });
-            }
-        });
-    },
-    locations(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        let siteCode = args.site;
-
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchAllLocations(siteCode,
-                        (error, result) => {
-                            if(error){
-                                let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                                reject(errorMsg);
-                            }else{
-                                resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Location'}));
-                            }
-                        });
-        });
-    },
-    removeKeywords(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const actionPost = args.input;
-        const siteId = actionPost.site;
-        const terms = actionPost.edges.map(term=>Object.assign({}, term, {PartitionKey: {'_': siteId}, RowKey: {'_': term.RowKey}}));
-
-        return new Promise((resolve, reject) => {
-            azureTableService.ModifyTermEntities(terms, siteId, azureTableService.AZURE_TABLE_BATCH_ACTIONS.DELETE,
-                    (error, result) => {
-                        if(error){
+                          if(error){
                             let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
                             reject(errorMsg);
-                        }else{
-                            resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Term'}));
-                        }
-                    });
-        });
-    },
-    addKeywords(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const actionPost = args.input;
-        const siteId = actionPost.site;
-        const terms = actionPost.edges.map(term=>Object.assign({}, term, {PartitionKey: {'_': siteId}, RowKey: {'_': term.RowKey}}));
-
-        return new Promise((resolve, reject) => {
-            azureTableService.ModifyTermEntities(terms, siteId, azureTableService.AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY,
-                    (error, result) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Term'}));
-                        }
-                    });
-        });
-    },
-    saveLocations(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const actionPost = args.input;
-        const siteId = actionPost.site;
-        const locations = actionPost.edges;
-
-        return new Promise((resolve, reject) => {
-            postgresMessageService.SaveLocalities(siteId, locations,
-                        (error, result) => {
-                            if(error){
-                                let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                                reject(errorMsg);
-                            }else{
-                                resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Location'}));
-                            }
-                        });
-        });
-    },
-    removeLocations(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const actionPost = args.input;
-        const siteId = actionPost.site;
-        const locations = actionPost.edges;
-
-        return new Promise((resolve, reject) => {
-            postgresMessageService.RemoveLocalities(siteId, locations,
-                    (error, result) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
+                          }else{
                             resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Location'}));
-                        }
-                    });
-        });
-    },
-    popularLocations(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-
-        let requestedLanguage = args.langCode || DEFAULT_LANGUAGE;
-        let site = args.site;
-        let timespan = args.timespan;
-        let sourceFilter = args.sourceFilter;
-        let fromDate = args.fromDate;
-        let toDate = args.toDate;
-        let limit = args.limit || DEFAULT_LIMIT;
-        let zoom = args.zoomLevel || DEFAULT_ZOOM_LEVEL;
-        let layertype = args.layertype || DEFAULT_LAYER_TYPE;
-
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchPopularLocations(site, requestedLanguage, limit, timespan, zoom, layertype, sourceFilter, fromDate, toDate,
-                    (error, results) => {
-                        if(error){
+                          }
+                        });
+      }else{
+        azureTableService.GetKeywordList(siteCode,
+                        (error, result) => {
+                          if(error){
                             let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
                             reject(errorMsg);
-                        }else{
-                            let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
-                            resolve(messages);
-                        }
-                    });
-        });
-    },
-    timeSeries(args, res){ // eslint-disable-line no-unused-vars
-        const site = args.site;
-        const fromDate = args.fromDate;
-        const toDate = args.toDate;
-        const limit = args.limit || DEFAULT_LIMIT;
-        const zoom = args.zoomLevel || DEFAULT_ZOOM_LEVEL;
-        const layertype = args.layertype || DEFAULT_LAYER_TYPE;
-        const dataSource = args.sourceFilter;
-        const mainEdge = args.mainEdge;
+                          }else{
+                            resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Term'}));
+                          }
+                        });
+      }
+    });
+  },
+  locations(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    let siteCode = args.site;
 
-        return new Promise((resolve, reject) => {
-            postgresMessageService.EdgeTimeSeries(site, limit, zoom, layertype, fromDate, toDate, mainEdge, dataSource,
-                    (error, results) => {
-                        if(error || !(results.labels && results.graphData)){
-                            let errorMsg = `Internal time series server error: [${JSON.stringify(error)}]`;
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchAllLocations(siteCode,
+                        (error, result) => {
+                          if(error){
+                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
                             reject(errorMsg);
-                        }else{
-                            resolve(results);
-                        }
-                    });
-        });
-    },
+                          }else{
+                            resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Location'}));
+                          }
+                        });
+    });
+  },
+  removeKeywords(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const actionPost = args.input;
+    const siteId = actionPost.site;
+    const terms = actionPost.edges.map(term=>Object.assign({}, term, {PartitionKey: {'_': siteId}, RowKey: {'_': term.RowKey}}));
 
-    topSources(args,res) { // eslint-disable-line no-unused-vars
-        let fromDate = args.fromDate;
-        let toDate = args.toDate;
-        const site = args.site;
-        const limit = args.limit;
-        const sourceFilter = args.sourceFilter;
-        const term = args.mainTerm;
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchTopSources(site,fromDate,toDate,limit,term,sourceFilter,
-                    (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal top sources error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let collection = Object.assign({}, {sources: results});
-                            resolve(collection);
-                        }
+    return new Promise((resolve, reject) => {
+      azureTableService.ModifyTermEntities(terms, siteId, azureTableService.AZURE_TABLE_BATCH_ACTIONS.DELETE,
+                    (error, result) => {
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Term'}));
+                      }
                     });
-        });
-    }
+    });
+  },
+  addKeywords(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const actionPost = args.input;
+    const siteId = actionPost.site;
+    const terms = actionPost.edges.map(term=>Object.assign({}, term, {PartitionKey: {'_': siteId}, RowKey: {'_': term.RowKey}}));
+
+    return new Promise((resolve, reject) => {
+      azureTableService.ModifyTermEntities(terms, siteId, azureTableService.AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY,
+                    (error, result) => {
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Term'}));
+                      }
+                    });
+    });
+  },
+  saveLocations(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const actionPost = args.input;
+    const siteId = actionPost.site;
+    const locations = actionPost.edges;
+
+    return new Promise((resolve, reject) => {
+      postgresMessageService.SaveLocalities(siteId, locations,
+                        (error, result) => {
+                          if(error){
+                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                            reject(errorMsg);
+                          }else{
+                            resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Location'}));
+                          }
+                        });
+    });
+  },
+  removeLocations(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const actionPost = args.input;
+    const siteId = actionPost.site;
+    const locations = actionPost.edges;
+
+    return new Promise((resolve, reject) => {
+      postgresMessageService.RemoveLocalities(siteId, locations,
+                    (error, result) => {
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        resolve(Object.assign({}, {'runTime': Date.now() - startTime, 'edges': result, 'type': 'Location'}));
+                      }
+                    });
+    });
+  },
+  popularLocations(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+
+    let requestedLanguage = args.langCode || DEFAULT_LANGUAGE;
+    let site = args.site;
+    let timespan = args.timespan;
+    let sourceFilter = args.sourceFilter;
+    let fromDate = args.fromDate;
+    let toDate = args.toDate;
+    let limit = args.limit || DEFAULT_LIMIT;
+    let zoom = args.zoomLevel || DEFAULT_ZOOM_LEVEL;
+    let layertype = args.layertype || DEFAULT_LAYER_TYPE;
+
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchPopularLocations(site, requestedLanguage, limit, timespan, zoom, layertype, sourceFilter, fromDate, toDate,
+                    (error, results) => {
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
+                        resolve(messages);
+                      }
+                    });
+    });
+  },
+  timeSeries(args, res){ // eslint-disable-line no-unused-vars
+    const site = args.site;
+    const fromDate = args.fromDate;
+    const toDate = args.toDate;
+    const limit = args.limit || DEFAULT_LIMIT;
+    const zoom = args.zoomLevel || DEFAULT_ZOOM_LEVEL;
+    const layertype = args.layertype || DEFAULT_LAYER_TYPE;
+    const dataSource = args.sourceFilter;
+    const mainEdge = args.mainEdge;
+
+    return new Promise((resolve, reject) => {
+      postgresMessageService.EdgeTimeSeries(site, limit, zoom, layertype, fromDate, toDate, mainEdge, dataSource,
+                    (error, results) => {
+                      if(error || !(results.labels && results.graphData)){
+                        let errorMsg = `Internal time series server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        resolve(results);
+                      }
+                    });
+    });
+  },
+
+  topSources(args,res) { // eslint-disable-line no-unused-vars
+    let fromDate = args.fromDate;
+    let toDate = args.toDate;
+    const site = args.site;
+    const limit = args.limit;
+    const sourceFilter = args.sourceFilter;
+    const term = args.mainTerm;
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchTopSources(site,fromDate,toDate,limit,term,sourceFilter,
+                    (error, results) => {
+                      if(error){
+                        let errorMsg = `Internal top sources error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let collection = Object.assign({}, {sources: results});
+                        resolve(collection);
+                      }
+                    });
+    });
+  }
 };

--- a/src/resolvers/Facts.js
+++ b/src/resolvers/Facts.js
@@ -4,36 +4,36 @@ let Promise = require('promise');
 let blobStorageManager = require('../storageClients/BlobStorageFactsManager');
 
 module.exports = {
-    list(args, res) { // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
+  list(args, res) { // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
 
 
-        let promise = new Promise((resolve, reject) => {
-            blobStorageManager.FetchFacts(args.pageSize, args.skip, args.tagFilter, (results, error) => {
+    let promise = new Promise((resolve, reject) => {
+      blobStorageManager.FetchFacts(args.pageSize, args.skip, args.tagFilter, (results, error) => {
 
-                if (error) {
-                    reject(`Error occured retrieving facts. [${error}]`);
-                } else {
-                    let facts = { 'type': 'FactCollection', facts: results, runTime: Date.now() - startTime };
-                    resolve(facts);
-                }
-            });
-        }, console.log);
+        if (error) {
+          reject(`Error occured retrieving facts. [${error}]`);
+        } else {
+          let facts = { 'type': 'FactCollection', facts: results, runTime: Date.now() - startTime };
+          resolve(facts);
+        }
+      });
+    }, console.log);
 
-        return promise;
-    },
+    return promise;
+  },
 
-    get(args, res) { // eslint-disable-line no-unused-vars
-        let promise = new Promise((resolve, reject) => {
-            blobStorageManager.GetFact(args.id, (result, error) => {
-                if (error) {
-                    reject(`Error occured retrieving facts. [${error}]`);
-                } else {
-                    resolve(result);
-                }
-            });
-        }, console.log);
+  get(args, res) { // eslint-disable-line no-unused-vars
+    let promise = new Promise((resolve, reject) => {
+      blobStorageManager.GetFact(args.id, (result, error) => {
+        if (error) {
+          reject(`Error occured retrieving facts. [${error}]`);
+        } else {
+          resolve(result);
+        }
+      });
+    }, console.log);
 
-        return promise;
-    }
+    return promise;
+  }
 };

--- a/src/resolvers/Locations.js
+++ b/src/resolvers/Locations.js
@@ -9,30 +9,30 @@ let Promise = require('promise');
 let postgresMessageService = require('../postgresClients/PostgresLocationManager');
 
 module.exports = {
-    popularLocations(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
+  popularLocations(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
 
-        let requestedLanguage = args.langCode || DEFAULT_LANGUAGE;
-        let site = args.site;
-        let timespan = args.timespan;
-        let fromDate = args.fromDate;
-        let toDate = args.toDate;
-        let sourceFilter = args.sourceFilter;
-        let limit = args.limit || DEFAULT_LIMIT;
-        let zoom = args.zoomLevel || DEFAULT_ZOOM_LEVEL;
-        let layertype = args.layertype || DEFAULT_LAYER_TYPE;
+    let requestedLanguage = args.langCode || DEFAULT_LANGUAGE;
+    let site = args.site;
+    let timespan = args.timespan;
+    let fromDate = args.fromDate;
+    let toDate = args.toDate;
+    let sourceFilter = args.sourceFilter;
+    let limit = args.limit || DEFAULT_LIMIT;
+    let zoom = args.zoomLevel || DEFAULT_ZOOM_LEVEL;
+    let layertype = args.layertype || DEFAULT_LAYER_TYPE;
 
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchPopularLocations(site, requestedLanguage, limit, timespan, zoom, layertype, sourceFilter, fromDate, toDate,
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchPopularLocations(site, requestedLanguage, limit, timespan, zoom, layertype, sourceFilter, fromDate, toDate,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
-                            resolve(messages);
-                        }
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
+                        resolve(messages);
+                      }
                     });
-        });
-    }
+    });
+  }
 };

--- a/src/resolvers/Messages.js
+++ b/src/resolvers/Messages.js
@@ -9,142 +9,142 @@ const DEFAULT_LIMIT = 20;
 const DEFAULT_LANGUAGE = 'en';
 
 module.exports = {
-    byBbox(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
+  byBbox(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
 
-        let requestedLanguage = args.langCode;
-        let bbox = args.bbox;
-        let site = args.site;
-        let originalSource = args.originalSource;
-        let filteredEdges = args.filteredEdges;
-        let fromDate = args.fromDate || '11/5/2016';
-        let toDate = args.toDate || '11/7/2016';
-        let mainTerm = args.mainTerm;
+    let requestedLanguage = args.langCode;
+    let bbox = args.bbox;
+    let site = args.site;
+    let originalSource = args.originalSource;
+    let filteredEdges = args.filteredEdges;
+    let fromDate = args.fromDate || '11/5/2016';
+    let toDate = args.toDate || '11/7/2016';
+    let mainTerm = args.mainTerm;
 
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchSentences(site, originalSource, bbox, undefined, mainTerm, fromDate, toDate, args.limit, args.offset,
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchSentences(site, originalSource, bbox, undefined, mainTerm, fromDate, toDate, args.limit, args.offset,
                     filteredEdges, requestedLanguage, args.sourceFilter, args.fulltextTerm,
                         (error, results) => {
-                            if(error){
-                                let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
-                                reject(errorMsg);
-                            }else{
-                                let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
-                                resolve(messages);
-                            }
-                        });
-        });
-    },
-    byLocation(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-
-        let requestedLanguage = args.langCode;
-        let originalSource = args.originalSource;
-        let filteredEdges = args.filteredEdges;
-        let coordinates = args.coordinates;
-        let fromDate = args.fromDate;
-        let toDate = args.toDate;
-        let site = args.site;
-        let limit = args.limit || DEFAULT_LIMIT;
-        let offset = args.offset || 0;
-
-        if(coordinates.length !== 2){
-            throw new Error('Empty tileId error.');
-        }
-
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchSentences(site, originalSource, undefined, coordinates, undefined, fromDate, toDate, limit, offset,
-                    filteredEdges, requestedLanguage, args.sourceFilter, args.fulltextTerm,
-                        (error, results) => {
-                            if(error){
-                                let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
-                                reject(errorMsg);
-                            }else{
-                                let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
-                                resolve(messages);
-                            }
-                        });
-        });
-    },
-    byEdges(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-
-        let requestedLanguage = args.langCode;
-        let filteredEdges = args.filteredEdges;
-        let fromDate = args.fromDate;
-        let toDate = args.toDate;
-        let site = args.site;
-        let originalSource = args.originalSource;
-        let limit = args.limit || DEFAULT_LIMIT;
-        let offset = args.offset || 0;
-
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchSentences(site, originalSource, undefined, undefined, undefined, fromDate, toDate, limit, offset,
-                    filteredEdges, requestedLanguage, args.sourceFilter, args.fulltextTerm,
-                        (error, results) => {
-                            if(error){
-                                let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
-                                reject(errorMsg);
-                            }else{
-                                let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
-                                resolve(messages);
-                            }
-                        });
-        });
-    },
-    event(args, res){ // eslint-disable-line no-unused-vars
-        const messageId = args.messageId;
-        const site = args.site;
-        const langCode = args.langCode || DEFAULT_LANGUAGE;
-        const dataSources = args.dataSources;
-
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchEvent(site, messageId, dataSources, langCode,
-                        (error, results) => {
-                            if(error){
-                                let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
-                                reject(errorMsg);
-                            }else{
-                                resolve(results);
-                            }
-                        });
-        });
-    },
-
-    publishEvents(args, res){ // eslint-disable-line no-unused-vars
-        const actionPost = args.input;
-        const messages = actionPost.messages;
-
-        return new Promise((resolve, reject) => {
-            azureQueueManager.customEvents(messages,
-                    (error, result) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                          if(error){
+                            let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
                             reject(errorMsg);
-                        }else{
-                            resolve(result);
-                        }
-                    });
-        });
-    },
+                          }else{
+                            let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
+                            resolve(messages);
+                          }
+                        });
+    });
+  },
+  byLocation(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
 
-    translate(args, res) { // eslint-disable-line no-unused-vars
-        let sentence = args.sentence;
-        let fromLanguage = args.fromLanguage;
-        let toLanguage = args.toLanguage;
+    let requestedLanguage = args.langCode;
+    let originalSource = args.originalSource;
+    let filteredEdges = args.filteredEdges;
+    let coordinates = args.coordinates;
+    let fromDate = args.fromDate;
+    let toDate = args.toDate;
+    let site = args.site;
+    let limit = args.limit || DEFAULT_LIMIT;
+    let offset = args.offset || 0;
 
-        return new Promise((resolve, reject) => {
-            translatorService.translate(sentence, fromLanguage, toLanguage).then( result => resolve({ translatedSentence: result.translatedSentence, originalSentence: sentence }), error => reject(error));
-        });
-    },
-
-    translateWords(args, res) { // eslint-disable-line no-unused-vars
-        let wordsToTranslate = args.words;
-        let fromLanguage = args.fromLanguage;
-        let toLanguage = args.toLanguage;
-
-        return new Promise((resolve, reject) => {
-            translatorService.translateSentenceArray(wordsToTranslate, fromLanguage, toLanguage).then( result => resolve({ words: result.translatedSentence }), error => reject(error));
-        });
+    if(coordinates.length !== 2){
+      throw new Error('Empty tileId error.');
     }
+
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchSentences(site, originalSource, undefined, coordinates, undefined, fromDate, toDate, limit, offset,
+                    filteredEdges, requestedLanguage, args.sourceFilter, args.fulltextTerm,
+                        (error, results) => {
+                          if(error){
+                            let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
+                            reject(errorMsg);
+                          }else{
+                            let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
+                            resolve(messages);
+                          }
+                        });
+    });
+  },
+  byEdges(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+
+    let requestedLanguage = args.langCode;
+    let filteredEdges = args.filteredEdges;
+    let fromDate = args.fromDate;
+    let toDate = args.toDate;
+    let site = args.site;
+    let originalSource = args.originalSource;
+    let limit = args.limit || DEFAULT_LIMIT;
+    let offset = args.offset || 0;
+
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchSentences(site, originalSource, undefined, undefined, undefined, fromDate, toDate, limit, offset,
+                    filteredEdges, requestedLanguage, args.sourceFilter, args.fulltextTerm,
+                        (error, results) => {
+                          if(error){
+                            let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
+                            reject(errorMsg);
+                          }else{
+                            let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
+                            resolve(messages);
+                          }
+                        });
+    });
+  },
+  event(args, res){ // eslint-disable-line no-unused-vars
+    const messageId = args.messageId;
+    const site = args.site;
+    const langCode = args.langCode || DEFAULT_LANGUAGE;
+    const dataSources = args.dataSources;
+
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchEvent(site, messageId, dataSources, langCode,
+                        (error, results) => {
+                          if(error){
+                            let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
+                            reject(errorMsg);
+                          }else{
+                            resolve(results);
+                          }
+                        });
+    });
+  },
+
+  publishEvents(args, res){ // eslint-disable-line no-unused-vars
+    const actionPost = args.input;
+    const messages = actionPost.messages;
+
+    return new Promise((resolve, reject) => {
+      azureQueueManager.customEvents(messages,
+                    (error, result) => {
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        resolve(result);
+                      }
+                    });
+    });
+  },
+
+  translate(args, res) { // eslint-disable-line no-unused-vars
+    let sentence = args.sentence;
+    let fromLanguage = args.fromLanguage;
+    let toLanguage = args.toLanguage;
+
+    return new Promise((resolve, reject) => {
+      translatorService.translate(sentence, fromLanguage, toLanguage).then( result => resolve({ translatedSentence: result.translatedSentence, originalSentence: sentence }), error => reject(error));
+    });
+  },
+
+  translateWords(args, res) { // eslint-disable-line no-unused-vars
+    let wordsToTranslate = args.words;
+    let fromLanguage = args.fromLanguage;
+    let toLanguage = args.toLanguage;
+
+    return new Promise((resolve, reject) => {
+      translatorService.translateSentenceArray(wordsToTranslate, fromLanguage, toLanguage).then( result => resolve({ words: result.translatedSentence }), error => reject(error));
+    });
+  }
 };

--- a/src/resolvers/Settings.js
+++ b/src/resolvers/Settings.js
@@ -9,319 +9,319 @@ const cassandraConnector = require('../connectors/CassandraConnector');
 const TOPICS_SEED_CONTAINER = 'settings';
 
 module.exports = {
-    sites(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const siteId = args.siteId;
-        return new Promise((resolve, reject) => {
-            azureTableService.GetSiteDefinition(siteId,
+  sites(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const siteId = args.siteId;
+    return new Promise((resolve, reject) => {
+      azureTableService.GetSiteDefinition(siteId,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let siteCollection = Object.assign({}, {runTime: Date.now() - startTime, sites: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let siteCollection = Object.assign({}, {runTime: Date.now() - startTime, sites: results});
 
-                            resolve(siteCollection);
-                        }
+                        resolve(siteCollection);
+                      }
                     });
-        });
-    },
+    });
+  },
 
-    createOrReplaceSite(args, res){  // eslint-disable-line no-unused-vars
-        const siteDefinition = args.input;
-        const siteType = siteDefinition.siteType;
+  createOrReplaceSite(args, res){  // eslint-disable-line no-unused-vars
+    const siteDefinition = args.input;
+    const siteType = siteDefinition.siteType;
 
-        return new Promise((resolve, reject) => {
-            if(siteType && siteType.length > 0) {
-                cassandraConnector.openClient()
+    return new Promise((resolve, reject) => {
+      if(siteType && siteType.length > 0) {
+        cassandraConnector.openClient()
           .then((client) => {
-              return insertSeedTopics(client, siteType);
+            return insertSeedTopics(client, siteType);
           })
           .then(() => {
-              return azureTableService.InsertOrReplaceSiteDefinitionAsync(siteDefinition);
+            return azureTableService.InsertOrReplaceSiteDefinitionAsync(siteDefinition);
           })
           .then(result => {
-              resolve(result && result.length > 0 ? result[0] : {});
+            resolve(result && result.length > 0 ? result[0] : {});
           })
           .catch(err => {
-              reject(err);
+            reject(err);
           });
-            } else {
-                azureTableService.InsertOrReplaceSiteDefinitionAsync(siteDefinition)
+      } else {
+        azureTableService.InsertOrReplaceSiteDefinitionAsync(siteDefinition)
           .then(result => {
-              resolve(result && result.length > 0 ? result[0] : {});
+            resolve(result && result.length > 0 ? result[0] : {});
           })
           .catch(err => {
-              reject(err);
+            reject(err);
           });
-            }
-        });
-    },
+      }
+    });
+  },
 
-    modifyFacebookPages(args, res){  // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const inputDefinition = args.input;
-        const fbPages = inputDefinition.pages.map(page => Object.assign({}, page, {PartitionKey: {'_': inputDefinition.site}, RowKey: {'_': page.RowKey}}));
+  modifyFacebookPages(args, res){  // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const inputDefinition = args.input;
+    const fbPages = inputDefinition.pages.map(page => Object.assign({}, page, {PartitionKey: {'_': inputDefinition.site}, RowKey: {'_': page.RowKey}}));
 
-        return new Promise((resolve, reject) => {
-            azureTableService.ModifyFacebookPages(inputDefinition.site, fbPages, azureTableService.AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY,
+    return new Promise((resolve, reject) => {
+      azureTableService.ModifyFacebookPages(inputDefinition.site, fbPages, azureTableService.AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, pages: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, pages: results});
 
-                            resolve(acctCollection);
-                        }
+                        resolve(acctCollection);
+                      }
                     });
-        });
-    },
-    modifyTrustedTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const inputDefinition = args.input;
-        console.log(inputDefinition);
-        console.log('Modifying collection');
+    });
+  },
+  modifyTrustedTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const inputDefinition = args.input;
+    console.log(inputDefinition);
+    console.log('Modifying collection');
 
-        const trustedAccts = inputDefinition.accounts.map(page => Object.assign({}, page, {PartitionKey: {'_': inputDefinition.site}, RowKey: {'_': page.RowKey}}));
+    const trustedAccts = inputDefinition.accounts.map(page => Object.assign({}, page, {PartitionKey: {'_': inputDefinition.site}, RowKey: {'_': page.RowKey}}));
 
-        console.log(trustedAccts);
-        return new Promise((resolve, reject) => {
-            azureTableService.ModifyTrustedTwitterAccounts(inputDefinition.site, trustedAccts, azureTableService.AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY,
+    console.log(trustedAccts);
+    return new Promise((resolve, reject) => {
+      azureTableService.ModifyTrustedTwitterAccounts(inputDefinition.site, trustedAccts, azureTableService.AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
 
-                            resolve(acctCollection);
-                        }
+                        resolve(acctCollection);
+                      }
                     });
-        });
-    },
-    removeFacebookPages(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const inputDefinition = args.input;
-        const fbPages = inputDefinition.pages.map(page => Object.assign({}, page, {PartitionKey: {'_': inputDefinition.site}, RowKey: {'_': page.RowKey}}));
+    });
+  },
+  removeFacebookPages(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const inputDefinition = args.input;
+    const fbPages = inputDefinition.pages.map(page => Object.assign({}, page, {PartitionKey: {'_': inputDefinition.site}, RowKey: {'_': page.RowKey}}));
 
-        return new Promise((resolve, reject) => {
-            azureTableService.ModifyFacebookPages(inputDefinition.site, fbPages, azureTableService.AZURE_TABLE_BATCH_ACTIONS.DELETE,
+    return new Promise((resolve, reject) => {
+      azureTableService.ModifyFacebookPages(inputDefinition.site, fbPages, azureTableService.AZURE_TABLE_BATCH_ACTIONS.DELETE,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, pages: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, pages: results});
 
-                            resolve(acctCollection);
-                        }
+                        resolve(acctCollection);
+                      }
                     });
-        });
-    },
-    removeTrustedTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const inputDefinition = args.input;
-        const trustedAccts = inputDefinition.accounts.map(page => Object.assign({}, page, {PartitionKey: {'_': inputDefinition.site}, RowKey: {'_': page.RowKey}}));
+    });
+  },
+  removeTrustedTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const inputDefinition = args.input;
+    const trustedAccts = inputDefinition.accounts.map(page => Object.assign({}, page, {PartitionKey: {'_': inputDefinition.site}, RowKey: {'_': page.RowKey}}));
 
-        return new Promise((resolve, reject) => {
-            azureTableService.ModifyTrustedTwitterAccounts(inputDefinition.site, trustedAccts, azureTableService.AZURE_TABLE_BATCH_ACTIONS.DELETE,
+    return new Promise((resolve, reject) => {
+      azureTableService.ModifyTrustedTwitterAccounts(inputDefinition.site, trustedAccts, azureTableService.AZURE_TABLE_BATCH_ACTIONS.DELETE,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
 
-                            resolve(acctCollection);
-                        }
+                        resolve(acctCollection);
+                      }
                     });
-        });
-    },
-    modifyTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const twitterAccountDefintions = args.input;
-        const twitterAccounts = twitterAccountDefintions.accounts.map(account => Object.assign({}, account, {PartitionKey: {'_': twitterAccountDefintions.site}, RowKey: {'_': account.accountName}}));
+    });
+  },
+  modifyTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const twitterAccountDefintions = args.input;
+    const twitterAccounts = twitterAccountDefintions.accounts.map(account => Object.assign({}, account, {PartitionKey: {'_': twitterAccountDefintions.site}, RowKey: {'_': account.accountName}}));
 
-        return new Promise((resolve, reject) => {
-            azureTableService.ModifyTwitterAccounts(twitterAccountDefintions.site, twitterAccounts, azureTableService.AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY,
+    return new Promise((resolve, reject) => {
+      azureTableService.ModifyTwitterAccounts(twitterAccountDefintions.site, twitterAccounts, azureTableService.AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
 
-                            resolve(acctCollection);
-                        }
+                        resolve(acctCollection);
+                      }
                     });
-        });
-    },
-    removeTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const twitterAccountDefintions = args.input;
-        const twitterAccounts = twitterAccountDefintions.accounts.map(account => Object.assign({}, account, {PartitionKey: {'_': twitterAccountDefintions.site}, RowKey: {'_': account.accountName}}));
+    });
+  },
+  removeTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const twitterAccountDefintions = args.input;
+    const twitterAccounts = twitterAccountDefintions.accounts.map(account => Object.assign({}, account, {PartitionKey: {'_': twitterAccountDefintions.site}, RowKey: {'_': account.accountName}}));
 
-        return new Promise((resolve, reject) => {
-            azureTableService.ModifyTwitterAccounts(twitterAccountDefintions.site, twitterAccounts, azureTableService.AZURE_TABLE_BATCH_ACTIONS.DELETE,
+    return new Promise((resolve, reject) => {
+      azureTableService.ModifyTwitterAccounts(twitterAccountDefintions.site, twitterAccounts, azureTableService.AZURE_TABLE_BATCH_ACTIONS.DELETE,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
 
-                            resolve(acctCollection);
-                        }
+                        resolve(acctCollection);
+                      }
                     });
-        });
-    },
-    twitterAccounts(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const siteId = args.siteId;
-        return new Promise((resolve, reject) => {
-            azureTableService.GetTwitterAccounts(siteId,
+    });
+  },
+  twitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const siteId = args.siteId;
+    return new Promise((resolve, reject) => {
+      azureTableService.GetTwitterAccounts(siteId,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let acctCollection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
 
-                            resolve(acctCollection);
-                        }
+                        resolve(acctCollection);
+                      }
                     });
-        });
-    },
-    trustedTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const siteId = args.siteId;
-        return new Promise((resolve, reject) => {
-            azureTableService.GetTrustedTwitterAccounts(siteId,
+    });
+  },
+  trustedTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const siteId = args.siteId;
+    return new Promise((resolve, reject) => {
+      azureTableService.GetTrustedTwitterAccounts(siteId,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let collection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let collection = Object.assign({}, {runTime: Date.now() - startTime, accounts: results});
 
-                            resolve(collection);
-                        }
+                        resolve(collection);
+                      }
                     });
-        });
-    },
-    facebookPages(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const siteId = args.siteId;
-        return new Promise((resolve, reject) => {
-            azureTableService.GetFacebookPages(siteId,
+    });
+  },
+  facebookPages(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const siteId = args.siteId;
+    return new Promise((resolve, reject) => {
+      azureTableService.GetFacebookPages(siteId,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let collection = Object.assign({}, {runTime: Date.now() - startTime, pages: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let collection = Object.assign({}, {runTime: Date.now() - startTime, pages: results});
 
-                            resolve(collection);
-                        }
+                        resolve(collection);
+                      }
                     });
-        });
-    },
-    facebookAnalytics(args, res) { // eslint-disable-line no-unused-vars
-        const days = args.days;
-        const site = args.siteId;
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchFacebookAnalytics(site,days,
+    });
+  },
+  facebookAnalytics(args, res) { // eslint-disable-line no-unused-vars
+    const days = args.days;
+    const site = args.siteId;
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchFacebookAnalytics(site,days,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal facebook analytics error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let collection = Object.assign({}, {analytics: results});
-                            resolve(collection);
-                        }
+                      if(error){
+                        let errorMsg = `Internal facebook analytics error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let collection = Object.assign({}, {analytics: results});
+                        resolve(collection);
+                      }
                     });
-        });
-    },
-    termBlacklist(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const siteId = args.siteId;
-        return new Promise((resolve, reject) => {
-            azureTableService.GetBlacklistTerms(siteId,
+    });
+  },
+  termBlacklist(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const siteId = args.siteId;
+    return new Promise((resolve, reject) => {
+      azureTableService.GetBlacklistTerms(siteId,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let collection = Object.assign({}, {runTime: Date.now() - startTime, filters: results});
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let collection = Object.assign({}, {runTime: Date.now() - startTime, filters: results});
 
-                            resolve(collection);
-                        }
+                        resolve(collection);
+                      }
                     });
-        });
-    },
-    modifyBlacklist(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const blacklistTermDefinitions = args.input;
-        const blacklistTerms = blacklistTermDefinitions.terms.map(item => Object.assign({}, {PartitionKey: {'_': blacklistTermDefinitions.site}, RowKey: {'_': item.RowKey}, filteredTerms: JSON.stringify(item.filteredTerms), lang: item.lang}));
+    });
+  },
+  modifyBlacklist(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const blacklistTermDefinitions = args.input;
+    const blacklistTerms = blacklistTermDefinitions.terms.map(item => Object.assign({}, {PartitionKey: {'_': blacklistTermDefinitions.site}, RowKey: {'_': item.RowKey}, filteredTerms: JSON.stringify(item.filteredTerms), lang: item.lang}));
 
-        return new Promise((resolve, reject) => {
-            azureTableService.ModifyBlacklistTerms(blacklistTerms, blacklistTermDefinitions.site, azureTableService.AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY,
+    return new Promise((resolve, reject) => {
+      azureTableService.ModifyBlacklistTerms(blacklistTerms, blacklistTermDefinitions.site, azureTableService.AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY,
                     (error, results) => {
-                        if(error){
-                            const errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            const termCollection = Object.assign({}, {runTime: Date.now() - startTime, filters: results});
-                            resolve(termCollection);
-                        }
+                      if(error){
+                        const errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        const termCollection = Object.assign({}, {runTime: Date.now() - startTime, filters: results});
+                        resolve(termCollection);
+                      }
                     });
-        });
-    },
-    removeBlacklist(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const blacklistTermDefinitions = args.input;
-        const blacklistTerms = blacklistTermDefinitions.terms.map(item => Object.assign({}, item, {PartitionKey: {'_': blacklistTermDefinitions.site}, RowKey: {'_': item.RowKey}}));
+    });
+  },
+  removeBlacklist(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const blacklistTermDefinitions = args.input;
+    const blacklistTerms = blacklistTermDefinitions.terms.map(item => Object.assign({}, item, {PartitionKey: {'_': blacklistTermDefinitions.site}, RowKey: {'_': item.RowKey}}));
 
-        return new Promise((resolve, reject) => {
-            azureTableService.ModifyBlacklistTerms(blacklistTerms, blacklistTermDefinitions.site, azureTableService.AZURE_TABLE_BATCH_ACTIONS.DELETE,
+    return new Promise((resolve, reject) => {
+      azureTableService.ModifyBlacklistTerms(blacklistTerms, blacklistTermDefinitions.site, azureTableService.AZURE_TABLE_BATCH_ACTIONS.DELETE,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            const termCollection = Object.assign({}, {runTime: Date.now() - startTime, filters: results});
-                            resolve(termCollection);
-                        }
+                      if(error){
+                        let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        const termCollection = Object.assign({}, {runTime: Date.now() - startTime, filters: results});
+                        resolve(termCollection);
+                      }
                     });
-        });
-    }
+    });
+  }
 };
 
 let insertSeedTopics = (client, siteType) => {
-    return new Promise((resolve, reject) => {
-        blobStorageManager.getBlobNamesWithSiteType(TOPICS_SEED_CONTAINER, siteType)
+  return new Promise((resolve, reject) => {
+    blobStorageManager.getBlobNamesWithSiteType(TOPICS_SEED_CONTAINER, siteType)
        .then(blobNames => {
-           return blobStorageManager.List(TOPICS_SEED_CONTAINER, blobNames);
+         return blobStorageManager.List(TOPICS_SEED_CONTAINER, blobNames);
        })
        .then(blobsTopics => {
-           return blobsTopics.collection;
+         return blobsTopics.collection;
        })
        .then(topics => {
-           let queries = [];
-           for(let topic of topics) {
-               queries.push(cassandraTableStorageManager.prepareInsertTopic(topic));
-           }
-           return queries;
+         let queries = [];
+         for(let topic of topics) {
+           queries.push(cassandraTableStorageManager.prepareInsertTopic(topic));
+         }
+         return queries;
        })
        .then(queries => {
-           return cassandraTableStorageManager.batch(client, queries);
+         return cassandraTableStorageManager.batch(client, queries);
        })
        .then(() => {
-           resolve();
+         resolve();
        })
        .catch(err => {
-           reject(err);
+         reject(err);
        });
-    });
+  });
 };

--- a/src/resolvers/Settings.js
+++ b/src/resolvers/Settings.js
@@ -6,8 +6,6 @@ const blobStorageManager = require('../storageClients/BlobStorageManager');
 const cassandraTableStorageManager = require('../storageClients/CassandraTableStorageManager');
 const cassandraConnector = require('../connectors/CassandraConnector');
 
-const DEFAULT_LANGUAGE = 'en';
-
 const TOPICS_SEED_CONTAINER = 'settings';
 
 module.exports = {

--- a/src/resolvers/Settings.js
+++ b/src/resolvers/Settings.js
@@ -34,7 +34,7 @@ module.exports = {
     return new Promise((resolve, reject) => {
       if(siteType && siteType.length > 0) {
         cassandraConnector.openClient()
-          .then((client) => {
+          .then(client => {
             return insertSeedTopics(client, siteType);
           })
           .then(() => {
@@ -43,17 +43,13 @@ module.exports = {
           .then(result => {
             resolve(result && result.length > 0 ? result[0] : {});
           })
-          .catch(err => {
-            reject(err);
-          });
+          .catch(reject);
       } else {
         azureTableService.InsertOrReplaceSiteDefinitionAsync(siteDefinition)
           .then(result => {
             resolve(result && result.length > 0 ? result[0] : {});
           })
-          .catch(err => {
-            reject(err);
-          });
+          .catch(reject);
       }
     });
   },
@@ -300,9 +296,9 @@ module.exports = {
 
 let insertSeedTopics = (client, siteType) => {
   return new Promise((resolve, reject) => {
-    blobStorageManager.getBlobNamesWithSiteType(TOPICS_SEED_CONTAINER, siteType)
+    blobStorageManager.getBlobNamesWithSiteType(siteType)
        .then(blobNames => {
-         return blobStorageManager.List(TOPICS_SEED_CONTAINER, blobNames);
+         return blobStorageManager.List(blobNames);
        })
        .then(blobsTopics => {
          return blobsTopics.collection;
@@ -317,11 +313,7 @@ let insertSeedTopics = (client, siteType) => {
        .then(queries => {
          return cassandraTableStorageManager.batch(client, queries);
        })
-       .then(() => {
-         resolve();
-       })
-       .catch(err => {
-         reject(err);
-       });
+       .then(resolve)
+       .catch(reject);
   });
 };

--- a/src/resolvers/Settings.js
+++ b/src/resolvers/Settings.js
@@ -24,6 +24,7 @@ module.exports = {
     },
     createOrReplaceSite(args, res){
         const siteDefinition = args.input;
+        const siteType = siteDefinition.siteType;
 
         return new Promise((resolve, reject) => {
             azureTableService.InsertOrReplaceSiteDefinition(siteDefinition,
@@ -32,6 +33,28 @@ module.exports = {
                             let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;
                             reject(errorMsg);
                         }else{
+                            /*
+                            Only thing worth adding is that you’ll need to write the keyword entries into Cassandra from
+                            the create site resolver function. Check out some the storageClient examples on how we’re doing
+                            storage writes for Postgres and Azure table as examples. You can use Datastax node-js driver to
+                             manage the communication between graphql and Cassandra https://github.com/datastax/nodejs-driver .
+                             Also, the input type SiteDefinition will now accept an additional parameter called siteType.
+                             You should only invoke the topic persistence step if that attribute is provided, as this will only be
+                             provided when the deployment script invokes this service.
+                            The Admin interface will never define this attribute, as its intent is to
+                            infer which keywords to pre-populate the site with.
+                            */
+                            if(siteType && siteType.length > 0){
+                               /*
+                               Get data from blob storage but just for the one that is associated with the siteType!
+                               accept the siteType input parameter and reference all topics for the input {type} from blob storage.
+                               Store data into cassandra tables - Push one record in the Topics table in Cassandra
+                               for each topic sourced from our blob storage container.
+                               */
+
+
+                            }
+
                             resolve(result && result.length > 0 ? result[0] : {});
                         }
                     });

--- a/src/resolvers/Settings.js
+++ b/src/resolvers/Settings.js
@@ -27,7 +27,7 @@ module.exports = {
         });
     },
 
-    createOrReplaceSite(args, res){
+    createOrReplaceSite(args, res){  // eslint-disable-line no-unused-vars
         const siteDefinition = args.input;
         const siteType = siteDefinition.siteType;
 
@@ -58,7 +58,7 @@ module.exports = {
         });
     },
 
-    modifyFacebookPages(args, res){
+    modifyFacebookPages(args, res){  // eslint-disable-line no-unused-vars
         const startTime = Date.now();
         const inputDefinition = args.input;
         const fbPages = inputDefinition.pages.map(page => Object.assign({}, page, {PartitionKey: {'_': inputDefinition.site}, RowKey: {'_': page.RowKey}}));

--- a/src/resolvers/Settings.js
+++ b/src/resolvers/Settings.js
@@ -22,11 +22,11 @@ module.exports = {
                     });
         });
     },
-    createOrReplaceSite(args, res){ // eslint-disable-line no-unused-vars
-        const siteDefintion = args.input;
+    createOrReplaceSite(args, res){
+        const siteDefinition = args.input;
 
         return new Promise((resolve, reject) => {
-            azureTableService.InsertOrReplaceSiteDefinition(siteDefintion,
+            azureTableService.InsertOrReplaceSiteDefinition(siteDefinition,
                     (error, result) => {
                         if(error){
                             let errorMsg = `Internal location server error: [${JSON.stringify(error)}]`;

--- a/src/resolvers/Settings.js
+++ b/src/resolvers/Settings.js
@@ -6,8 +6,6 @@ const blobStorageManager = require('../storageClients/BlobStorageManager');
 const cassandraTableStorageManager = require('../storageClients/CassandraTableStorageManager');
 const cassandraConnector = require('../connectors/CassandraConnector');
 
-const TOPICS_SEED_CONTAINER = 'settings';
-
 module.exports = {
   sites(args, res){ // eslint-disable-line no-unused-vars
     const startTime = Date.now();

--- a/src/resolvers/Tiles.js
+++ b/src/resolvers/Tiles.js
@@ -12,156 +12,156 @@ let tileService = require('../osmClients/TileServiceManager');
 let geotile = require('geotile');
 
 function CoordinatesToNearbyTiles(multiPointArray){
-    let tileSet = new Set();
+  let tileSet = new Set();
 
-    multiPointArray.forEach(feature => {
-        const radiusDistanceBbox = new GeoPoint(feature[1], feature[0]).boundingCoordinates(RADIUS_DISTANCE_IN_MILES);
-        const tileBbox = {north:radiusDistanceBbox[1].latitude(), west: radiusDistanceBbox[0].longitude(), east: radiusDistanceBbox[1].longitude(), south: radiusDistanceBbox[0].latitude()};
-        geotile.tileIdsForBoundingBox(tileBbox, DEFAULT_ZOOM_LEVEL).forEach(tile=>tileSet.add(tile));
-    });
+  multiPointArray.forEach(feature => {
+    const radiusDistanceBbox = new GeoPoint(feature[1], feature[0]).boundingCoordinates(RADIUS_DISTANCE_IN_MILES);
+    const tileBbox = {north:radiusDistanceBbox[1].latitude(), west: radiusDistanceBbox[0].longitude(), east: radiusDistanceBbox[1].longitude(), south: radiusDistanceBbox[0].latitude()};
+    geotile.tileIdsForBoundingBox(tileBbox, DEFAULT_ZOOM_LEVEL).forEach(tile=>tileSet.add(tile));
+  });
 
-    return Array.from(tileSet);
+  return Array.from(tileSet);
 }
 
 module.exports = {
-    fetchTilesByBBox(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const filters = args.filteredEdges || [];
-        const bbox = args.bbox;
-        const layerType = args.layerType || DEFAULT_LAYER_TYPE;
-        const mainTerm = args.mainEdge;
-        const site = args.site;
-        const timespan = args.timespan;
-        const fromDate = args.fromDate;
-        const toDate = args.toDate;
-        const sourceFilter = args.sourceFilter;
-        const zoom = args.zoomLevel || DEFAULT_ZOOM_LEVEL;
+  fetchTilesByBBox(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const filters = args.filteredEdges || [];
+    const bbox = args.bbox;
+    const layerType = args.layerType || DEFAULT_LAYER_TYPE;
+    const mainTerm = args.mainEdge;
+    const site = args.site;
+    const timespan = args.timespan;
+    const fromDate = args.fromDate;
+    const toDate = args.toDate;
+    const sourceFilter = args.sourceFilter;
+    const zoom = args.zoomLevel || DEFAULT_ZOOM_LEVEL;
 
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchTilesByBbox(site, bbox, zoom, filters, mainTerm, timespan, layerType, sourceFilter, fromDate, toDate,
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchTilesByBbox(site, bbox, zoom, filters, mainTerm, timespan, layerType, sourceFilter, fromDate, toDate,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
-                            resolve(messages);
-                        }
+                      if(error){
+                        let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
+                        resolve(messages);
+                      }
                     });
-        });
-    },
+    });
+  },
 
-    fetchTilesByLocations(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const locations = args.locations;
+  fetchTilesByLocations(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const locations = args.locations;
 
-        if(locations.length > 0){
-            const tileIds = CoordinatesToNearbyTiles(locations);
-            const filters = args.filteredEdges || [];
-            const layerType = args.layerType || DEFAULT_LAYER_TYPE;
-            const timespan = args.timespan;
-            const fromDate = args.fromDate;
-            const toDate = args.toDate;
-            const site = args.site;
-            const sourceFilter = args.sourceFilter;
+    if(locations.length > 0){
+      const tileIds = CoordinatesToNearbyTiles(locations);
+      const filters = args.filteredEdges || [];
+      const layerType = args.layerType || DEFAULT_LAYER_TYPE;
+      const timespan = args.timespan;
+      const fromDate = args.fromDate;
+      const toDate = args.toDate;
+      const site = args.site;
+      const sourceFilter = args.sourceFilter;
 
-            return new Promise((resolve, reject) => {
-                postgresMessageService.FetchTilesByIds(site, tileIds, filters, timespan, layerType, sourceFilter, fromDate, toDate,
+      return new Promise((resolve, reject) => {
+        postgresMessageService.FetchTilesByIds(site, tileIds, filters, timespan, layerType, sourceFilter, fromDate, toDate,
                     (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
-                            resolve(messages);
-                        }
+                      if(error){
+                        let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
+                        resolve(messages);
+                      }
                     });
-            });
-        }else{
-            throw new Error('Empty location list error');
-        }
-    },
-
-    fetchPlacesByBBox(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const bbox = args.bbox;
-
-        if(bbox.length === 4){
-            const zoom = args.zoom || DEFAULT_PLACE_ZOOM_LEVEL;
-            const site = args.site;
-            const populationMin = args.populationMin;
-            const populationMax = args.populationMax;
-
-            return new Promise((resolve, reject) => {
-                tileService.FetchTilesInsideBbox(site, bbox, zoom, populationMin, populationMax,
-                    (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let featureCollection = Object.assign({}, results, {bbox: bbox, type: 'FeatureCollection', runTime: Date.now() - startTime, features: results});
-                            resolve(featureCollection);
-                        }
-                    });
-            });
-        }else{
-            throw new Error('Empty bbox error');
-        }
-    },
-
-    fetchEdgesByLocations(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const locations = args.locations;
-
-        if(locations.length > 0){
-            const tileIds = CoordinatesToNearbyTiles(locations);
-            const layerType = args.layerType || DEFAULT_LAYER_TYPE;
-            const timespan = args.timespan;
-            const fromDate = args.fromDate;
-            const toDate = args.toDate;
-            const site = args.site;
-            const sourceFilter = args.sourceFilter;
-
-            return new Promise((resolve, reject) => {
-                postgresMessageService.FetchEdgesByTileIds(site, tileIds, timespan, layerType, sourceFilter, fromDate, toDate,
-                    (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
-                            resolve(messages);
-                        }
-                    });
-            });
-        }else{
-            throw new Error('Empty location list error');
-        }
-    },
-
-    fetchEdgesByBBox(args, res){ // eslint-disable-line no-unused-vars
-        const startTime = Date.now();
-        const layerType = args.layerType || DEFAULT_LAYER_TYPE;
-        const timespan = args.timespan;
-        const fromDate = args.fromDate;
-        const toDate = args.toDate;
-        const bbox = args.bbox;
-        const site = args.site;
-        const zoom = args.zoomLevel || DEFAULT_ZOOM_LEVEL;
-        const sourceFilter = args.sourceFilter;
-        const mainTerm = args.mainEdge;
-
-        return new Promise((resolve, reject) => {
-            postgresMessageService.FetchEdgesByTerm(site, bbox, zoom, mainTerm, timespan, layerType, sourceFilter, fromDate, toDate,
-                    (error, results) => {
-                        if(error){
-                            let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
-                            reject(errorMsg);
-                        }else{
-                            let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
-                            resolve(messages);
-                        }
-                    });
-        });
+      });
+    }else{
+      throw new Error('Empty location list error');
     }
+  },
+
+  fetchPlacesByBBox(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const bbox = args.bbox;
+
+    if(bbox.length === 4){
+      const zoom = args.zoom || DEFAULT_PLACE_ZOOM_LEVEL;
+      const site = args.site;
+      const populationMin = args.populationMin;
+      const populationMax = args.populationMax;
+
+      return new Promise((resolve, reject) => {
+        tileService.FetchTilesInsideBbox(site, bbox, zoom, populationMin, populationMax,
+                    (error, results) => {
+                      if(error){
+                        let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let featureCollection = Object.assign({}, results, {bbox: bbox, type: 'FeatureCollection', runTime: Date.now() - startTime, features: results});
+                        resolve(featureCollection);
+                      }
+                    });
+      });
+    }else{
+      throw new Error('Empty bbox error');
+    }
+  },
+
+  fetchEdgesByLocations(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const locations = args.locations;
+
+    if(locations.length > 0){
+      const tileIds = CoordinatesToNearbyTiles(locations);
+      const layerType = args.layerType || DEFAULT_LAYER_TYPE;
+      const timespan = args.timespan;
+      const fromDate = args.fromDate;
+      const toDate = args.toDate;
+      const site = args.site;
+      const sourceFilter = args.sourceFilter;
+
+      return new Promise((resolve, reject) => {
+        postgresMessageService.FetchEdgesByTileIds(site, tileIds, timespan, layerType, sourceFilter, fromDate, toDate,
+                    (error, results) => {
+                      if(error){
+                        let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
+                        resolve(messages);
+                      }
+                    });
+      });
+    }else{
+      throw new Error('Empty location list error');
+    }
+  },
+
+  fetchEdgesByBBox(args, res){ // eslint-disable-line no-unused-vars
+    const startTime = Date.now();
+    const layerType = args.layerType || DEFAULT_LAYER_TYPE;
+    const timespan = args.timespan;
+    const fromDate = args.fromDate;
+    const toDate = args.toDate;
+    const bbox = args.bbox;
+    const site = args.site;
+    const zoom = args.zoomLevel || DEFAULT_ZOOM_LEVEL;
+    const sourceFilter = args.sourceFilter;
+    const mainTerm = args.mainEdge;
+
+    return new Promise((resolve, reject) => {
+      postgresMessageService.FetchEdgesByTerm(site, bbox, zoom, mainTerm, timespan, layerType, sourceFilter, fromDate, toDate,
+                    (error, results) => {
+                      if(error){
+                        let errorMsg = `Internal tile server error: [${JSON.stringify(error)}]`;
+                        reject(errorMsg);
+                      }else{
+                        let messages = Object.assign({}, results, {runTime: Date.now() - startTime});
+                        resolve(messages);
+                      }
+                    });
+    });
+  }
 };

--- a/src/resolvers/Topics.js
+++ b/src/resolvers/Topics.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const blobStorageManager = require('../storageClients/BlobStorageManager');
 
 //appInsights.setup();
-//appInsights.client.config.samplingPercentage = 0; // 0% of all telemetry will be sent to Application Insights 
+//appInsights.client.config.samplingPercentage = 0;
 //appInsights.start();
 
 module.exports = {

--- a/src/resolvers/Topics.js
+++ b/src/resolvers/Topics.js
@@ -1,33 +1,33 @@
-"use strict"
+'use strict';
 
-const Promise = require("bluebird");
+const Promise = require('bluebird');
 const appInsights = require('applicationinsights');
-const blobStorageManager = require("../storageClients/BlobStorageManager");
+const blobStorageManager = require('../storageClients/BlobStorageManager');
 
 //appInsights.setup();
 //appInsights.client.config.samplingPercentage = 0; // 0% of all telemetry will be sent to Application Insights 
 //appInsights.start();
 
 module.exports = {
-  get(args) {
-    return new Promise((resolve, reject) => {
-      blobStorageManager.Get(args.containerName, args.blobName, args.id)
+    get(args) {
+        return new Promise((resolve, reject) => {
+            blobStorageManager.Get(args.containerName, args.blobName, args.id)
         .then(response => {
-          resolve(response);
+            resolve(response);
         }).catch(err => {
-          reject(err);
+            reject(err);
         });
-     });
-  },
-  list(args) {
-    return new Promise((resolve, reject) => {
-      blobStorageManager.List(args.containerName, args.blobName)
+        });
+    },
+    list(args) {
+        return new Promise((resolve, reject) => {
+            blobStorageManager.List(args.containerName, args.blobName)
         .then(response => {
-          resolve(response);
+            resolve(response);
         })
         .catch(err => {
-          reject(err);
+            reject(err);
         });
-    });
-  }
+        });
+    }
 };

--- a/src/resolvers/Topics.js
+++ b/src/resolvers/Topics.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Promise = require('bluebird');
-const appInsights = require('applicationinsights');
+//const appInsights = require('applicationinsights');
 const blobStorageManager = require('../storageClients/BlobStorageManager');
 
 //appInsights.setup();

--- a/src/resolvers/Topics.js
+++ b/src/resolvers/Topics.js
@@ -4,25 +4,25 @@ const Promise = require('bluebird');
 const blobStorageManager = require('../storageClients/BlobStorageManager');
 
 module.exports = {
-    get(args) {
-        return new Promise((resolve, reject) => {
-            blobStorageManager.Get(args.containerName, args.blobName, args.id)
+  get(args) {
+    return new Promise((resolve, reject) => {
+      blobStorageManager.Get(args.containerName, args.blobName, args.id)
                 .then(response => {
-                    resolve(response);
-                 }).catch(err => {
-                    reject(err);
-                 });
-        });
-    },
-    list(args) {
-        return new Promise((resolve, reject) => {
-            blobStorageManager.List(args.containerName, args.blobName)
+                  resolve(response);
+                }).catch(err => {
+                  reject(err);
+                });
+    });
+  },
+  list(args) {
+    return new Promise((resolve, reject) => {
+      blobStorageManager.List(args.containerName, args.blobName)
         .then(response => {
-            resolve(response);
+          resolve(response);
         })
         .catch(err => {
-            reject(err);
+          reject(err);
         });
-        });
-    }
+    });
+  }
 };

--- a/src/resolvers/Topics.js
+++ b/src/resolvers/Topics.js
@@ -1,11 +1,12 @@
 "use strict"
 
-let Promise = require('promise');
-var appInsights = require('applicationinsights');
+const Promise = require("bluebird");
+const appInsights = require('applicationinsights');
+const blobStorageManager = require("../storageClients/BlobStorageManager");
+
 //appInsights.setup();
 //appInsights.client.config.samplingPercentage = 0; // 0% of all telemetry will be sent to Application Insights 
 //appInsights.start();
-let blobStorageManager = require("../storageClients/BlobStorageManager");
 
 module.exports = {
   get(args) {

--- a/src/resolvers/Topics.js
+++ b/src/resolvers/Topics.js
@@ -6,23 +6,16 @@ const blobStorageManager = require('../storageClients/BlobStorageManager');
 module.exports = {
   get(args) {
     return new Promise((resolve, reject) => {
-      blobStorageManager.Get(args.containerName, args.blobName, args.id)
-        .then(response => {
-          resolve(response);
-        }).catch(err => {
-          reject(err);
-        });
+      blobStorageManager.Get(args.blobName, args.id)
+        .then(resolve)
+        .catch(reject);
     });
   },
   list(args) {
     return new Promise((resolve, reject) => {
-      blobStorageManager.List(args.containerName, args.blobName)
-        .then(response => {
-          resolve(response);
-        })
-        .catch(err => {
-          reject(err);
-        });
+      blobStorageManager.List(args.blobName)
+        .then(resolve)
+        .catch(reject);
     });
   }
 };

--- a/src/resolvers/Topics.js
+++ b/src/resolvers/Topics.js
@@ -1,0 +1,35 @@
+"use strict"
+
+let Promise = require('promise');
+var appInsights = require('applicationinsights');
+//appInsights.setup();
+//appInsights.client.config.samplingPercentage = 0; // 0% of all telemetry will be sent to Application Insights 
+//appInsights.start();
+let blobStorageManager = require("../storageClients/BlobStorageManager");
+
+module.exports = {
+  get(args) {
+    return new Promise((resolve, reject) => {
+      blobStorageManager.Get(args.containerName, args.blobName, args.id)
+        .then(function(response) {
+          resolve(result);
+        }).catch(function(err) {
+          reject(err);
+        });
+     });
+  },
+  //TODO: finish writing this
+   list(args) {
+     const startTime = Date.now();
+     return new Promise((resolve, reject) => {
+       blobStorageManager.Fetch(args.pageSize, args.skip, args.tagFilter, (results, error) => {
+         if (error) {
+           reject(`Error occured retrieving items. [${error}]`);
+         } else {
+           let response = { items: results, runTime: Date.now() - startTime };
+           resolve(response);
+         }
+       });
+     });
+   }
+};

--- a/src/resolvers/Topics.js
+++ b/src/resolvers/Topics.js
@@ -1,22 +1,17 @@
 'use strict';
 
 const Promise = require('bluebird');
-//const appInsights = require('applicationinsights');
 const blobStorageManager = require('../storageClients/BlobStorageManager');
-
-//appInsights.setup();
-//appInsights.client.config.samplingPercentage = 0;
-//appInsights.start();
 
 module.exports = {
     get(args) {
         return new Promise((resolve, reject) => {
             blobStorageManager.Get(args.containerName, args.blobName, args.id)
-        .then(response => {
-            resolve(response);
-        }).catch(err => {
-            reject(err);
-        });
+                .then(response => {
+                    resolve(response);
+                 }).catch(err => {
+                    reject(err);
+                 });
         });
     },
     list(args) {

--- a/src/resolvers/Topics.js
+++ b/src/resolvers/Topics.js
@@ -11,25 +11,22 @@ module.exports = {
   get(args) {
     return new Promise((resolve, reject) => {
       blobStorageManager.Get(args.containerName, args.blobName, args.id)
-        .then(function(response) {
-          resolve(result);
-        }).catch(function(err) {
+        .then(response => {
+          resolve(response);
+        }).catch(err => {
           reject(err);
         });
      });
   },
-  //TODO: finish writing this
-   list(args) {
-     const startTime = Date.now();
-     return new Promise((resolve, reject) => {
-       blobStorageManager.Fetch(args.pageSize, args.skip, args.tagFilter, (results, error) => {
-         if (error) {
-           reject(`Error occured retrieving items. [${error}]`);
-         } else {
-           let response = { items: results, runTime: Date.now() - startTime };
-           resolve(response);
-         }
-       });
-     });
-   }
+  list(args) {
+    return new Promise((resolve, reject) => {
+      blobStorageManager.List(args.containerName, args.blobName)
+        .then(response => {
+          resolve(response);
+        })
+        .catch(err => {
+          reject(err);
+        });
+    });
+  }
 };

--- a/src/resolvers/Topics.js
+++ b/src/resolvers/Topics.js
@@ -7,11 +7,11 @@ module.exports = {
   get(args) {
     return new Promise((resolve, reject) => {
       blobStorageManager.Get(args.containerName, args.blobName, args.id)
-                .then(response => {
-                  resolve(response);
-                }).catch(err => {
-                  reject(err);
-                });
+        .then(response => {
+          resolve(response);
+        }).catch(err => {
+          reject(err);
+        });
     });
   },
   list(args) {

--- a/src/schemas/TopicsSchema.js
+++ b/src/schemas/TopicsSchema.js
@@ -1,0 +1,13 @@
+var graphql = require('graphql');
+ 
+module.exports = graphql.buildSchema(`
+  type TopicCollection {
+    id: Int!,
+    topic: String!,
+    value: String!
+  }
+  
+  type Query {
+    get(containerName: String!, blobName: String!, id: Int!): TopicCollection
+  }
+`);

--- a/src/schemas/TopicsSchema.js
+++ b/src/schemas/TopicsSchema.js
@@ -1,13 +1,19 @@
 var graphql = require('graphql');
  
 module.exports = graphql.buildSchema(`
-  type TopicCollection {
+
+  type Topic {
     id: Int!,
     topic: String!,
     value: String!
   }
+
+  type TopicCollection {
+    collection: [Topic]!
+  }
   
   type Query {
-    get(containerName: String!, blobName: String!, id: Int!): TopicCollection
+    get(containerName: String!, blobName: String!, id: Int!): Topic
+    list(containerName: String!, blobName: String!): TopicCollection
   }
 `);

--- a/src/schemas/TopicsSchema.js
+++ b/src/schemas/TopicsSchema.js
@@ -13,7 +13,7 @@ module.exports = graphql.buildSchema(`
   }
   
   type Query {
-    get(containerName: String!, blobName: String!, id: Int!): Topic
-    list(containerName: String!, blobName: String!): TopicCollection
+    get(blobName: String!, id: Int!): Topic
+    list(blobName: String!): TopicCollection
   }
 `);

--- a/src/storageClients/AzureQueueManager.js
+++ b/src/storageClients/AzureQueueManager.js
@@ -10,86 +10,86 @@ const DATE_FORMAT = 'MM/DD/YYYY HH:mm';
 const ASYNC_QUEUE_LIMIT = 50;
 
 function getAzureQueueService(){
-    let queueSvc = azure.createQueueService();
-    queueSvc.messageEncoder = new TextBase64QueueMessageEncoder();
-    queueSvc.createQueueIfNotExists(PRE_NLP_QUEUE, (error, result, response) => { // eslint-disable-line no-unused-vars
-        if (error) {
-            RaiseException(`Unable to create new azure queue ${PRE_NLP_QUEUE}`);
-        }
-    });
+  let queueSvc = azure.createQueueService();
+  queueSvc.messageEncoder = new TextBase64QueueMessageEncoder();
+  queueSvc.createQueueIfNotExists(PRE_NLP_QUEUE, (error, result, response) => { // eslint-disable-line no-unused-vars
+    if (error) {
+      RaiseException(`Unable to create new azure queue ${PRE_NLP_QUEUE}`);
+    }
+  });
 
-    return queueSvc;
+  return queueSvc;
 }
 
 function RaiseException(errorMsg) {
-    console.error('error occured: ' + errorMsg);
+  console.error('error occured: ' + errorMsg);
 }
 
 function pushMessageToStorageQueue(message, queueSvc, callback){
-    try {
-        queueSvc.createMessage(PRE_NLP_QUEUE, JSON.stringify(message), (error, result, response) => { // eslint-disable-line no-unused-vars
-            if (error) {
-                const errMsg = `Azure Queue push error occured error [${error}]`;
-                RaiseException(errMsg);
-                callback(errMsg);
-            }else{
-                console.log(`Wrote ${JSON.stringify(message)} to output queue.`);
-                callback();
-            }
-        });
-    } catch (error) {
-        RaiseException(`Issue with pushing message ${JSON.stringify(message)} to out queue.`);
-        return callback(error);
-    }
+  try {
+    queueSvc.createMessage(PRE_NLP_QUEUE, JSON.stringify(message), (error, result, response) => { // eslint-disable-line no-unused-vars
+      if (error) {
+        const errMsg = `Azure Queue push error occured error [${error}]`;
+        RaiseException(errMsg);
+        callback(errMsg);
+      }else{
+        console.log(`Wrote ${JSON.stringify(message)} to output queue.`);
+        callback();
+      }
+    });
+  } catch (error) {
+    RaiseException(`Issue with pushing message ${JSON.stringify(message)} to out queue.`);
+    return callback(error);
+  }
 }
 
 function processMessage(item, queueSvc, asyncCB){
-    let eventDate;
+  let eventDate;
 
-    try{
-        eventDate = moment(item.created_at, DATE_FORMAT, 'en').toISOString();
-    }catch(error){
-        let errMsg = `Failed parsing published event date for event ${JSON.stringify(item)}`;
-        RaiseException(errMsg);
-        asyncCB(errMsg);
-        return;
+  try{
+    eventDate = moment(item.created_at, DATE_FORMAT, 'en').toISOString();
+  }catch(error){
+    let errMsg = `Failed parsing published event date for event ${JSON.stringify(item)}`;
+    RaiseException(errMsg);
+    asyncCB(errMsg);
+    return;
+  }
+
+  let message = {
+    'source': 'custom',
+    'created_at': eventDate,
+    'lang': item.language,
+    'message': {
+      'id': item.RowKey,
+      'geo': item.featureCollection,
+      'message': item.message,
+      'link': item.link,
+      'originalSources': [item.source],
+      'title': item.title
     }
+  };
 
-    let message = {
-        'source': 'custom',
-        'created_at': eventDate,
-        'lang': item.language,
-        'message': {
-            'id': item.RowKey,
-            'geo': item.featureCollection,
-            'message': item.message,
-            'link': item.link,
-            'originalSources': [item.source],
-            'title': item.title
-        }
-    };
-
-    pushMessageToStorageQueue(message, queueSvc, asyncCB);
+  pushMessageToStorageQueue(message, queueSvc, asyncCB);
 }
 
 module.exports = {
-    customEvents(eventList, callback){
-        let queueSvc = getAzureQueueService();
-        if(eventList){
-            asyncEachLimit(eventList, ASYNC_QUEUE_LIMIT, (item, asyncCB)=>processMessage(item, queueSvc, asyncCB),
+  customEvents(eventList, callback){
+    let queueSvc = getAzureQueueService();
+    if(eventList){
+      asyncEachLimit(eventList, ASYNC_QUEUE_LIMIT, (item, asyncCB)=>processMessage(item, queueSvc, asyncCB),
                                finalCBErr => {
-                                   let processedEvents;
+                                 let processedEvents;
 
-                                   if(finalCBErr){
-                                       console.error(`Error occured publishing events: ${JSON.stringify(finalCBErr)}`);
-                                   }else{
-                                       console.log(`Finished writing ${eventList.length} to ${PRE_NLP_QUEUE}`);
-                                       processedEvents = eventList.map(ev=>ev.RowKey);
-                                   }
+                                 if(finalCBErr){
+                                   console.error(`Error occured publishing events: ${JSON.stringify(finalCBErr)}`);
+                                 }else{
+                                   console.log(`Finished writing ${eventList.length} to ${PRE_NLP_QUEUE}`);
+                                   processedEvents = eventList.map(ev=>ev.RowKey);
+                                 }
 
-                                   callback(finalCBErr, processedEvents);
+                                 callback(finalCBErr, processedEvents);
                                }
             );
-        }
     }
+  }
 };

--- a/src/storageClients/AzureTableStorageManager.js
+++ b/src/storageClients/AzureTableStorageManager.js
@@ -210,9 +210,9 @@ module.exports = {
             RowKey: siteDefinition.name
         });
 
-        tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result, response) => { // eslint-disable-line no-unused-vars
+        tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result) => { // eslint-disable-line no-unused-vars
             if(!error){
-                tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEntity, (error2, result, response) => {
+                tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEntity, (error2, result) => {
                     if(!error2){
                         FetchSiteDefinitions(siteDefinition.name, tableService, callback);
                     }else{

--- a/src/storageClients/AzureTableStorageManager.js
+++ b/src/storageClients/AzureTableStorageManager.js
@@ -10,332 +10,332 @@ const AZURE_TBL_TRUSTED_TWITTER_ACCOUNTS = 'fortisTrustedTwitterAccounts';
 const AZURE_TBL_SITES_PARTITION_KEY = 'site';
 const AZURE_TABLE_BATCH_MAX_OPERATIONS = 100;
 const AZURE_TABLE_BATCH_ACTIONS = {
-    DELETE: 1,
-    INSERT_OR_MODIFY: 2
+  DELETE: 1,
+  INSERT_OR_MODIFY: 2
 };
 
 function GetAzureTblBatchAction(offset, partitionKey, tasks, action){
-    const batch = new azureStorage.TableBatch();
+  const batch = new azureStorage.TableBatch();
 
-    if(Array.isArray(tasks) && offset < tasks.length){
-        const upperBounds = offset + AZURE_TABLE_BATCH_MAX_OPERATIONS < tasks.length ? offset + AZURE_TABLE_BATCH_MAX_OPERATIONS : tasks.length;
-        const batchTasks = tasks.slice(offset, upperBounds);
-        batchTasks.forEach(operation => {
-            const task = Object.assign({}, operation);
+  if(Array.isArray(tasks) && offset < tasks.length){
+    const upperBounds = offset + AZURE_TABLE_BATCH_MAX_OPERATIONS < tasks.length ? offset + AZURE_TABLE_BATCH_MAX_OPERATIONS : tasks.length;
+    const batchTasks = tasks.slice(offset, upperBounds);
+    batchTasks.forEach(operation => {
+      const task = Object.assign({}, operation);
 
-            if(action === AZURE_TABLE_BATCH_ACTIONS.DELETE){
-                batch.deleteEntity(task);
-            }else if(action === AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY){
-                batch.insertOrReplaceEntity(task);
-            }else{
-                console.error(`${action} is an unsupported azure table action`);
-            }
-        });
-    }
+      if(action === AZURE_TABLE_BATCH_ACTIONS.DELETE){
+        batch.deleteEntity(task);
+      }else if(action === AZURE_TABLE_BATCH_ACTIONS.INSERT_OR_MODIFY){
+        batch.insertOrReplaceEntity(task);
+      }else{
+        console.error(`${action} is an unsupported azure table action`);
+      }
+    });
+  }
 
-    return batch;
+  return batch;
 }
 
 function GetKeywordsFromAzureTbl(siteKey, tableService, callback){
-    const queryString = 'PartitionKey eq ?';
-    const query = new azureStorage.TableQuery().where(queryString, siteKey);
+  const queryString = 'PartitionKey eq ?';
+  const query = new azureStorage.TableQuery().where(queryString, siteKey);
 
-    tableService.createTableIfNotExists(AZURE_TBL_KEYWORD, (error, result, response) => { // eslint-disable-line no-unused-vars
+  tableService.createTableIfNotExists(AZURE_TBL_KEYWORD, (error, result, response) => { // eslint-disable-line no-unused-vars
+    if(!error){
+      tableService.queryEntities(AZURE_TBL_KEYWORD, query, null, (error, result, response) => { // eslint-disable-line no-unused-vars
         if(!error){
-            tableService.queryEntities(AZURE_TBL_KEYWORD, query, null, (error, result, response) => { // eslint-disable-line no-unused-vars
-                if(!error){
-                    callback(undefined, result.entries ? result.entries.map(term => {
-                        let keyword = {'type': 'Term', 'name': term.name._, 'RowKey': term.RowKey._};
-                        Object.keys(term).forEach(entityField=>{
-                            if(entityField.startsWith('name_') && term[entityField]._){
-                                keyword[entityField] = term[entityField]._.toLowerCase();
-                            }
-                        });
-
-                        return keyword;
-                    }) : []);
-                }else{
-                    callback(`There was an error querying table [${AZURE_TBL_SITES}] siteId[${siteKey}]`);
-                }
+          callback(undefined, result.entries ? result.entries.map(term => {
+            let keyword = {'type': 'Term', 'name': term.name._, 'RowKey': term.RowKey._};
+            Object.keys(term).forEach(entityField=>{
+              if(entityField.startsWith('name_') && term[entityField]._){
+                keyword[entityField] = term[entityField]._.toLowerCase();
+              }
             });
+
+            return keyword;
+          }) : []);
         }else{
-            callback('Error occured while trying to create azure table.', undefined);
+          callback(`There was an error querying table [${AZURE_TBL_SITES}] siteId[${siteKey}]`);
         }
-    });
+      });
+    }else{
+      callback('Error occured while trying to create azure table.', undefined);
+    }
+  });
 }
 
 function GetFbPagesFromAzureTbl(siteKey, tableService, callback){
-    const queryString = 'PartitionKey eq ?';
-    const query = new azureStorage.TableQuery().where(queryString, siteKey);
+  const queryString = 'PartitionKey eq ?';
+  const query = new azureStorage.TableQuery().where(queryString, siteKey);
 
-    tableService.createTableIfNotExists(AZURE_TBL_FB_PAGES, (error, result, response) => { // eslint-disable-line no-unused-vars
+  tableService.createTableIfNotExists(AZURE_TBL_FB_PAGES, (error, result, response) => { // eslint-disable-line no-unused-vars
+    if(!error){
+      tableService.queryEntities(AZURE_TBL_FB_PAGES, query, null, (error, result, response) => { // eslint-disable-line no-unused-vars
         if(!error){
-            tableService.queryEntities(AZURE_TBL_FB_PAGES, query, null, (error, result, response) => { // eslint-disable-line no-unused-vars
-                if(!error){
-                    callback(undefined, result.entries ? result.entries.map(page => Object.assign({}, {'pageUrl': page.pageUrl._, 'RowKey': page.RowKey._})) : []);
-                }else{
-                    callback(`There was an error querying table [${AZURE_TBL_FB_PAGES}] siteId[${siteKey}]`);
-                }
-            });
+          callback(undefined, result.entries ? result.entries.map(page => Object.assign({}, {'pageUrl': page.pageUrl._, 'RowKey': page.RowKey._})) : []);
         }else{
-            callback('Error occured while trying to create azure table.', undefined);
+          callback(`There was an error querying table [${AZURE_TBL_FB_PAGES}] siteId[${siteKey}]`);
         }
-    });
+      });
+    }else{
+      callback('Error occured while trying to create azure table.', undefined);
+    }
+  });
 }
 
 function GetBlacklistFromAzureTbl(siteKey, tableService, callback){
-    const queryString = 'PartitionKey eq ?';
-    const query = new azureStorage.TableQuery().where(queryString, siteKey);
+  const queryString = 'PartitionKey eq ?';
+  const query = new azureStorage.TableQuery().where(queryString, siteKey);
 
-    tableService.createTableIfNotExists(AZURE_TBL_BLACKLIST, (error, result, response) => { // eslint-disable-line no-unused-vars
+  tableService.createTableIfNotExists(AZURE_TBL_BLACKLIST, (error, result, response) => { // eslint-disable-line no-unused-vars
+    if(!error){
+      tableService.queryEntities(AZURE_TBL_BLACKLIST, query, null, (error, result, response) => { // eslint-disable-line no-unused-vars
         if(!error){
-            tableService.queryEntities(AZURE_TBL_BLACKLIST, query, null, (error, result, response) => { // eslint-disable-line no-unused-vars
-                if(!error){
-                    callback(undefined, result.entries ? result.entries.map(filter => {
-                        const filteredTerm = Object.assign({}, {
-                            'filteredTerms': filter.filteredTerms ? JSON.parse(filter.filteredTerms._) : [],
-                            'RowKey': filter.RowKey._,
-                            'lang': filter.lang._
-                        });
-
-                        return filteredTerm;
-                    }) : []);
-                }else{
-                    callback(`There was an error querying table [${AZURE_TBL_FB_PAGES}] siteId[${siteKey}]`);
-                }
+          callback(undefined, result.entries ? result.entries.map(filter => {
+            const filteredTerm = Object.assign({}, {
+              'filteredTerms': filter.filteredTerms ? JSON.parse(filter.filteredTerms._) : [],
+              'RowKey': filter.RowKey._,
+              'lang': filter.lang._
             });
+
+            return filteredTerm;
+          }) : []);
         }else{
-            callback('Error occured while trying to create azure table.', undefined);
+          callback(`There was an error querying table [${AZURE_TBL_FB_PAGES}] siteId[${siteKey}]`);
         }
-    });
+      });
+    }else{
+      callback('Error occured while trying to create azure table.', undefined);
+    }
+  });
 }
 
 function GetTwitterAccountsFromAzureTbl(siteKey, tableService, callback){
-    const queryString = 'PartitionKey eq ?';
-    const query = new azureStorage.TableQuery().where(queryString, siteKey);
+  const queryString = 'PartitionKey eq ?';
+  const query = new azureStorage.TableQuery().where(queryString, siteKey);
 
-    tableService.createTableIfNotExists(AZURE_TBL_TWITTER_ACCOUNTS, (error, result, response) => { // eslint-disable-line no-unused-vars
+  tableService.createTableIfNotExists(AZURE_TBL_TWITTER_ACCOUNTS, (error, result, response) => { // eslint-disable-line no-unused-vars
+    if(!error){
+      tableService.queryEntities(AZURE_TBL_TWITTER_ACCOUNTS, query, null, (error, result2, response) => { // eslint-disable-line no-unused-vars
         if(!error){
-            tableService.queryEntities(AZURE_TBL_TWITTER_ACCOUNTS, query, null, (error, result2, response) => { // eslint-disable-line no-unused-vars
-                if(!error){
-                    callback(undefined, result2.entries ? result2.entries.map(acct => {
-                        let account = {'consumerSecret': acct.consumerSecret ? acct.consumerSecret._ : '',
+          callback(undefined, result2.entries ? result2.entries.map(acct => {
+            let account = {'consumerSecret': acct.consumerSecret ? acct.consumerSecret._ : '',
                                            'consumerKey': acct.consumerKey ? acct.consumerKey._ : '',
                                            'accountName': acct.RowKey._,
                                            'token': acct.token ? acct.token._ : '',
                                            'tokenSecret': acct.tokenSecret ? acct.tokenSecret._ : ''
                                           };
 
-                        return account;
-                    }) : []);
-                }else{
-                    callback(`There was an error querying table [${AZURE_TBL_TWITTER_ACCOUNTS}] siteId[${siteKey}]`);
-                }
-            });
+            return account;
+          }) : []);
         }else{
-            callback('Error occured while trying to create azure table.', undefined);
+          callback(`There was an error querying table [${AZURE_TBL_TWITTER_ACCOUNTS}] siteId[${siteKey}]`);
         }
-    });
+      });
+    }else{
+      callback('Error occured while trying to create azure table.', undefined);
+    }
+  });
 }
 
 function GetTrustedTwitterAccountsFromAzureTbl(siteKey, tableService, callback){
-    const queryString = 'PartitionKey eq ?';
-    const query = new azureStorage.TableQuery().where(queryString, siteKey);
+  const queryString = 'PartitionKey eq ?';
+  const query = new azureStorage.TableQuery().where(queryString, siteKey);
 
-    tableService.createTableIfNotExists(AZURE_TBL_TRUSTED_TWITTER_ACCOUNTS, (error, result, response) => { // eslint-disable-line no-unused-vars
+  tableService.createTableIfNotExists(AZURE_TBL_TRUSTED_TWITTER_ACCOUNTS, (error, result, response) => { // eslint-disable-line no-unused-vars
+    if(!error){
+      tableService.queryEntities(AZURE_TBL_TRUSTED_TWITTER_ACCOUNTS, query, null, (error, result2, response) => { // eslint-disable-line no-unused-vars
         if(!error){
-            tableService.queryEntities(AZURE_TBL_TRUSTED_TWITTER_ACCOUNTS, query, null, (error, result2, response) => { // eslint-disable-line no-unused-vars
-                if(!error){
-                    callback(undefined, result2.entries ? result2.entries.map(account => Object.assign({}, {'acctUrl': account.acctUrl._, 'RowKey': account.RowKey._})) : []);
-                }else{
-                    callback(`There was an error querying table [${AZURE_TBL_FB_PAGES}] siteId[${siteKey}]`);
-                }
-            });
+          callback(undefined, result2.entries ? result2.entries.map(account => Object.assign({}, {'acctUrl': account.acctUrl._, 'RowKey': account.RowKey._})) : []);
         }else{
-            callback('Error occured while trying to create azure table.', undefined);
+          callback(`There was an error querying table [${AZURE_TBL_FB_PAGES}] siteId[${siteKey}]`);
         }
-    });
+      });
+    }else{
+      callback('Error occured while trying to create azure table.', undefined);
+    }
+  });
 }
 
 function FetchSiteDefinitions(siteId, tableService, callback){
-    const queryString = `PartitionKey eq ?${siteId ? ' and RowKey eq ?' : ''}`;
-    const query = new azureStorage.TableQuery().where(queryString, AZURE_TBL_SITES_PARTITION_KEY, siteId);
+  const queryString = `PartitionKey eq ?${siteId ? ' and RowKey eq ?' : ''}`;
+  const query = new azureStorage.TableQuery().where(queryString, AZURE_TBL_SITES_PARTITION_KEY, siteId);
 
-    tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result, response) => { // eslint-disable-line no-unused-vars
+  tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result, response) => { // eslint-disable-line no-unused-vars
+    if(!error){
+      tableService.queryEntities(AZURE_TBL_SITES, query, null, (error, result, response) => { // eslint-disable-line no-unused-vars
         if(!error){
-            tableService.queryEntities(AZURE_TBL_SITES, query, null, (error, result, response) => { // eslint-disable-line no-unused-vars
-                if(!error){
-                    const siteEntities = result.entries.map(site => {
-                        return {
-                            'name': site.RowKey._,
-                            'properties': {
-                                'logo': site.logo ? site.logo._ : '',
-                                'title': site.title ? site.title._ : '',
-                                'supportedLanguages': site.supportedLanguages ? JSON.parse(site.supportedLanguages._) : [],
-                                'defaultZoomLevel': site.defaultZoomLevel._,
-                                'fbToken': site.fbToken ? site.fbToken._ : '',
-                                'mapzenApiKey': site.mapzenApiKey ? site.mapzenApiKey._ : '',
-                                'targetBbox': site.targetBbox ? JSON.parse(site.targetBbox._) : [],
-                                'defaultLocation': site.defaultLocation ? JSON.parse(site.defaultLocation._) : [],
-                                'storageConnectionString': site.storageConnectionString ? site.storageConnectionString._ : '',
-                                'featuresConnectionString': site.featuresConnectionString ? site.featuresConnectionString._ : ''
-                            }
-                        };
-                    });
-                    callback(undefined, result.entries ? siteEntities : []);
-                }else{
-                    callback(`There was an error querying table [${AZURE_TBL_SITES}] siteId[${siteId}]`);
-                }
-            });
+          const siteEntities = result.entries.map(site => {
+            return {
+              'name': site.RowKey._,
+              'properties': {
+                'logo': site.logo ? site.logo._ : '',
+                'title': site.title ? site.title._ : '',
+                'supportedLanguages': site.supportedLanguages ? JSON.parse(site.supportedLanguages._) : [],
+                'defaultZoomLevel': site.defaultZoomLevel._,
+                'fbToken': site.fbToken ? site.fbToken._ : '',
+                'mapzenApiKey': site.mapzenApiKey ? site.mapzenApiKey._ : '',
+                'targetBbox': site.targetBbox ? JSON.parse(site.targetBbox._) : [],
+                'defaultLocation': site.defaultLocation ? JSON.parse(site.defaultLocation._) : [],
+                'storageConnectionString': site.storageConnectionString ? site.storageConnectionString._ : '',
+                'featuresConnectionString': site.featuresConnectionString ? site.featuresConnectionString._ : ''
+              }
+            };
+          });
+          callback(undefined, result.entries ? siteEntities : []);
         }else{
-            callback('Error occured while trying to create azure table.', undefined);
+          callback(`There was an error querying table [${AZURE_TBL_SITES}] siteId[${siteId}]`);
         }
-    });
+      });
+    }else{
+      callback('Error occured while trying to create azure table.', undefined);
+    }
+  });
 }
 
 module.exports = {
-    AZURE_TABLE_BATCH_ACTIONS,
-    GetSiteDefinition(siteId, callback){
-        FetchSiteDefinitions(siteId, azureStorage.createTableService(), callback);
-    },
+  AZURE_TABLE_BATCH_ACTIONS,
+  GetSiteDefinition(siteId, callback){
+    FetchSiteDefinitions(siteId, azureStorage.createTableService(), callback);
+  },
 
-    InsertOrReplaceSiteDefinition(siteDefinition, callback){
+  InsertOrReplaceSiteDefinition(siteDefinition, callback){
 
-        let tableService = azureStorage.createTableService();
-        const tableEntity = Object.assign({}, siteDefinition, {
-            defaultLocation: JSON.stringify(siteDefinition.defaultLocation),
-            targetBbox: JSON.stringify(siteDefinition.targetBbox),
-            supportedLanguages: JSON.stringify(siteDefinition.supportedLanguages),
-            PartitionKey: AZURE_TBL_SITES_PARTITION_KEY,
-            RowKey: siteDefinition.name
+    let tableService = azureStorage.createTableService();
+    const tableEntity = Object.assign({}, siteDefinition, {
+      defaultLocation: JSON.stringify(siteDefinition.defaultLocation),
+      targetBbox: JSON.stringify(siteDefinition.targetBbox),
+      supportedLanguages: JSON.stringify(siteDefinition.supportedLanguages),
+      PartitionKey: AZURE_TBL_SITES_PARTITION_KEY,
+      RowKey: siteDefinition.name
+    });
+
+    tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result, response) => { // eslint-disable-line no-unused-vars
+      if(!error){
+        tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEntity, (error2, result, response) => { // eslint-disable-line no-unused-vars
+          if(!error2){
+            FetchSiteDefinitions(siteDefinition.name, tableService, callback);
+          }else{
+            callback(`There was an error writing to table [${AZURE_TBL_SITES}] with definition[${JSON.stringify(tableEntity)}]`);
+          }
         });
+      }else{
+        callback('Error occured while trying to create azure table.', undefined);
+      }
+    });
+  },
 
-        tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result, response) => { // eslint-disable-line no-unused-vars
-            if(!error){
-                tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEntity, (error2, result, response) => { // eslint-disable-line no-unused-vars
-                    if(!error2){
-                        FetchSiteDefinitions(siteDefinition.name, tableService, callback);
-                    }else{
-                        callback(`There was an error writing to table [${AZURE_TBL_SITES}] with definition[${JSON.stringify(tableEntity)}]`);
-                    }
-                });
-            }else{
-                callback('Error occured while trying to create azure table.', undefined);
-            }
-        });
-    },
+  GetKeywordList(siteKey, callback){
+    GetKeywordsFromAzureTbl(siteKey, azureStorage.createTableService(), callback);
+  },
+  GetTwitterAccounts(siteKey, callback){
+    GetTwitterAccountsFromAzureTbl(siteKey, azureStorage.createTableService(), callback);
+  },
+  GetTrustedTwitterAccounts(siteKey, callback){
+    GetTrustedTwitterAccountsFromAzureTbl(siteKey, azureStorage.createTableService(), callback);
+  },
+  GetFacebookPages(siteKey, callback){
+    GetFbPagesFromAzureTbl(siteKey, azureStorage.createTableService(), callback);
+  },
+  GetBlacklistTerms(siteKey, callback){
+    GetBlacklistFromAzureTbl(siteKey, azureStorage.createTableService(), callback);
+  },
+  ModifyTermEntities(terms, siteKey, action, callback){
+    const tableService = azureStorage.createTableService();
+    let offset = 0, batchedOperationSize = 0;
+    while(offset < terms.length){
+      const batch = GetAzureTblBatchAction(offset, siteKey, terms, action);
+      batchedOperationSize += batch.size();
+      tableService.executeBatch(AZURE_TBL_KEYWORD, batch, (error, result, response) => { // eslint-disable-line no-unused-vars
+        if(error) {
+          callback('Error occured while trying to remove entities from azure table.', undefined);
 
-    GetKeywordList(siteKey, callback){
-        GetKeywordsFromAzureTbl(siteKey, azureStorage.createTableService(), callback);
-    },
-    GetTwitterAccounts(siteKey, callback){
-        GetTwitterAccountsFromAzureTbl(siteKey, azureStorage.createTableService(), callback);
-    },
-    GetTrustedTwitterAccounts(siteKey, callback){
-        GetTrustedTwitterAccountsFromAzureTbl(siteKey, azureStorage.createTableService(), callback);
-    },
-    GetFacebookPages(siteKey, callback){
-        GetFbPagesFromAzureTbl(siteKey, azureStorage.createTableService(), callback);
-    },
-    GetBlacklistTerms(siteKey, callback){
-        GetBlacklistFromAzureTbl(siteKey, azureStorage.createTableService(), callback);
-    },
-    ModifyTermEntities(terms, siteKey, action, callback){
-        const tableService = azureStorage.createTableService();
-        let offset = 0, batchedOperationSize = 0;
-        while(offset < terms.length){
-            const batch = GetAzureTblBatchAction(offset, siteKey, terms, action);
-            batchedOperationSize += batch.size();
-            tableService.executeBatch(AZURE_TBL_KEYWORD, batch, (error, result, response) => { // eslint-disable-line no-unused-vars
-                if(error) {
-                    callback('Error occured while trying to remove entities from azure table.', undefined);
-
-                    return;
-                }else if(batchedOperationSize === terms.length){//we removed all requested entities
-                    GetKeywordsFromAzureTbl(siteKey, tableService, callback);
-                }
-            });
-
-            offset += AZURE_TABLE_BATCH_MAX_OPERATIONS;
+          return;
+        }else if(batchedOperationSize === terms.length){//we removed all requested entities
+          GetKeywordsFromAzureTbl(siteKey, tableService, callback);
         }
-    },
-    ModifyBlacklistTerms(terms, siteKey, action, callback){
-        const tableService = azureStorage.createTableService();
-        let offset = 0, batchedOperationSize = 0;
-        while(offset < terms.length){
-            const batch = GetAzureTblBatchAction(offset, siteKey, terms, action);
-            batchedOperationSize += batch.size();
-            tableService.executeBatch(AZURE_TBL_BLACKLIST, batch, (error, result, response) => { // eslint-disable-line no-unused-vars
-                if(error) {
-                    callback('Error occured while trying to remove entities from azure table.', undefined);
+      });
 
-                    return;
-                }else if(batchedOperationSize === terms.length){//we removed all requested entities
-                    GetBlacklistFromAzureTbl(siteKey, tableService, callback);
-                }
-            });
-
-            offset += AZURE_TABLE_BATCH_MAX_OPERATIONS;
-        }
-    },
-    ModifyTwitterAccounts(siteId, twitterAccounts, action, callback){
-        const tableService = azureStorage.createTableService();
-        let offset = 0, batchedOperationSize = 0;
-
-        while(offset < twitterAccounts.length){
-            const batch = GetAzureTblBatchAction(offset, siteId, twitterAccounts, action);
-            batchedOperationSize += batch.size();
-            tableService.executeBatch(AZURE_TBL_TWITTER_ACCOUNTS, batch, (error, result, response) => { // eslint-disable-line no-unused-vars
-                if(error) {
-                    callback('Error occured while trying to remove entities from azure table.', undefined);
-
-                    return;
-                }else if(batchedOperationSize === twitterAccounts.length){//we removed all requested entities
-                    GetTwitterAccountsFromAzureTbl(siteId, tableService, callback);
-                }
-            });
-
-            offset += AZURE_TABLE_BATCH_MAX_OPERATIONS;
-        }
-    },
-    ModifyTrustedTwitterAccounts(siteId, trustedTwitterAccounts, action, callback){
-        const tableService = azureStorage.createTableService();
-        let offset = 0, batchedOperationSize = 0;
-
-        while(offset < trustedTwitterAccounts.length){
-            const batch = GetAzureTblBatchAction(offset, siteId, trustedTwitterAccounts, action);
-            batchedOperationSize += batch.size();
-            tableService.executeBatch(AZURE_TBL_TRUSTED_TWITTER_ACCOUNTS, batch, (error, result, response) => { // eslint-disable-line no-unused-vars
-                if(error) {
-                    callback('Error occured while trying to remove entities from azure table.', undefined);
-
-                    return;
-                }else if(batchedOperationSize === trustedTwitterAccounts.length){//we removed all requested entities
-                    GetTrustedTwitterAccountsFromAzureTbl(siteId, tableService, callback);
-                }
-            });
-
-            offset += AZURE_TABLE_BATCH_MAX_OPERATIONS;
-        }
-    },
-    ModifyFacebookPages(siteId, fbPages, action, callback){
-        const tableService = azureStorage.createTableService();
-        let offset = 0, batchedOperationSize = 0;
-
-        while(offset < fbPages.length){
-            const batch = GetAzureTblBatchAction(offset, siteId, fbPages, action);
-            batchedOperationSize += batch.size();
-            tableService.executeBatch(AZURE_TBL_FB_PAGES, batch, (error, result, response) => { // eslint-disable-line no-unused-vars
-                if(error) {
-                    callback('Error occured while trying to modify entities from azure table.', undefined);
-
-                    return;
-                }else if(batchedOperationSize === fbPages.length){//we removed all requested entities
-                    GetFbPagesFromAzureTbl(siteId, tableService, callback);
-                }
-            });
-
-            offset += AZURE_TABLE_BATCH_MAX_OPERATIONS;
-        }
+      offset += AZURE_TABLE_BATCH_MAX_OPERATIONS;
     }
+  },
+  ModifyBlacklistTerms(terms, siteKey, action, callback){
+    const tableService = azureStorage.createTableService();
+    let offset = 0, batchedOperationSize = 0;
+    while(offset < terms.length){
+      const batch = GetAzureTblBatchAction(offset, siteKey, terms, action);
+      batchedOperationSize += batch.size();
+      tableService.executeBatch(AZURE_TBL_BLACKLIST, batch, (error, result, response) => { // eslint-disable-line no-unused-vars
+        if(error) {
+          callback('Error occured while trying to remove entities from azure table.', undefined);
+
+          return;
+        }else if(batchedOperationSize === terms.length){//we removed all requested entities
+          GetBlacklistFromAzureTbl(siteKey, tableService, callback);
+        }
+      });
+
+      offset += AZURE_TABLE_BATCH_MAX_OPERATIONS;
+    }
+  },
+  ModifyTwitterAccounts(siteId, twitterAccounts, action, callback){
+    const tableService = azureStorage.createTableService();
+    let offset = 0, batchedOperationSize = 0;
+
+    while(offset < twitterAccounts.length){
+      const batch = GetAzureTblBatchAction(offset, siteId, twitterAccounts, action);
+      batchedOperationSize += batch.size();
+      tableService.executeBatch(AZURE_TBL_TWITTER_ACCOUNTS, batch, (error, result, response) => { // eslint-disable-line no-unused-vars
+        if(error) {
+          callback('Error occured while trying to remove entities from azure table.', undefined);
+
+          return;
+        }else if(batchedOperationSize === twitterAccounts.length){//we removed all requested entities
+          GetTwitterAccountsFromAzureTbl(siteId, tableService, callback);
+        }
+      });
+
+      offset += AZURE_TABLE_BATCH_MAX_OPERATIONS;
+    }
+  },
+  ModifyTrustedTwitterAccounts(siteId, trustedTwitterAccounts, action, callback){
+    const tableService = azureStorage.createTableService();
+    let offset = 0, batchedOperationSize = 0;
+
+    while(offset < trustedTwitterAccounts.length){
+      const batch = GetAzureTblBatchAction(offset, siteId, trustedTwitterAccounts, action);
+      batchedOperationSize += batch.size();
+      tableService.executeBatch(AZURE_TBL_TRUSTED_TWITTER_ACCOUNTS, batch, (error, result, response) => { // eslint-disable-line no-unused-vars
+        if(error) {
+          callback('Error occured while trying to remove entities from azure table.', undefined);
+
+          return;
+        }else if(batchedOperationSize === trustedTwitterAccounts.length){//we removed all requested entities
+          GetTrustedTwitterAccountsFromAzureTbl(siteId, tableService, callback);
+        }
+      });
+
+      offset += AZURE_TABLE_BATCH_MAX_OPERATIONS;
+    }
+  },
+  ModifyFacebookPages(siteId, fbPages, action, callback){
+    const tableService = azureStorage.createTableService();
+    let offset = 0, batchedOperationSize = 0;
+
+    while(offset < fbPages.length){
+      const batch = GetAzureTblBatchAction(offset, siteId, fbPages, action);
+      batchedOperationSize += batch.size();
+      tableService.executeBatch(AZURE_TBL_FB_PAGES, batch, (error, result, response) => { // eslint-disable-line no-unused-vars
+        if(error) {
+          callback('Error occured while trying to modify entities from azure table.', undefined);
+
+          return;
+        }else if(batchedOperationSize === fbPages.length){//we removed all requested entities
+          GetFbPagesFromAzureTbl(siteId, tableService, callback);
+        }
+      });
+
+      offset += AZURE_TABLE_BATCH_MAX_OPERATIONS;
+    }
+  }
 };

--- a/src/storageClients/AzureTableStorageManager.js
+++ b/src/storageClients/AzureTableStorageManager.js
@@ -212,7 +212,7 @@ module.exports = {
 
         tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result, response) => { // eslint-disable-line no-unused-vars
             if(!error){
-                 tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEntity, (error2, result, response) => {
+                tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEntity, (error2, result, response) => {
                     if(!error2){
                         FetchSiteDefinitions(siteDefinition.name, tableService, callback);
                     }else{

--- a/src/storageClients/AzureTableStorageManager.js
+++ b/src/storageClients/AzureTableStorageManager.js
@@ -200,6 +200,7 @@ module.exports = {
     },
 
     InsertOrReplaceSiteDefinition(siteDefinition, callback){
+
         let tableService = azureStorage.createTableService();
         const tableEntity = Object.assign({}, siteDefinition, {
             defaultLocation: JSON.stringify(siteDefinition.defaultLocation),

--- a/src/storageClients/AzureTableStorageManager.js
+++ b/src/storageClients/AzureTableStorageManager.js
@@ -199,21 +199,21 @@ module.exports = {
         FetchSiteDefinitions(siteId, azureStorage.createTableService(), callback);
     },
 
-    InsertOrReplaceSiteDefinition(siteDefintion, callback){
+    InsertOrReplaceSiteDefinition(siteDefinition, callback){
         let tableService = azureStorage.createTableService();
-        const tableEntity = Object.assign({}, siteDefintion, {
-            defaultLocation: JSON.stringify(siteDefintion.defaultLocation),
-            targetBbox: JSON.stringify(siteDefintion.targetBbox),
-            supportedLanguages: JSON.stringify(siteDefintion.supportedLanguages),
+        const tableEntity = Object.assign({}, siteDefinition, {
+            defaultLocation: JSON.stringify(siteDefinition.defaultLocation),
+            targetBbox: JSON.stringify(siteDefinition.targetBbox),
+            supportedLanguages: JSON.stringify(siteDefinition.supportedLanguages),
             PartitionKey: AZURE_TBL_SITES_PARTITION_KEY,
-            RowKey: siteDefintion.name
+            RowKey: siteDefinition.name
         });
 
         tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result, response) => { // eslint-disable-line no-unused-vars
             if(!error){
                  tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEntity, (error2, result, response) => {
                     if(!error2){
-                        FetchSiteDefinitions(siteDefintion.name, tableService, callback);
+                        FetchSiteDefinitions(siteDefinition.name, tableService, callback);
                     }else{
                         callback(`There was an error writing to table [${AZURE_TBL_SITES}] with definition[${JSON.stringify(tableEntity)}]`);
                     }

--- a/src/storageClients/AzureTableStorageManager.js
+++ b/src/storageClients/AzureTableStorageManager.js
@@ -210,9 +210,9 @@ module.exports = {
             RowKey: siteDefinition.name
         });
 
-        tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result) => { // eslint-disable-line no-unused-vars
+        tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result, response) => { // eslint-disable-line no-unused-vars
             if(!error){
-                tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEntity, (error2, result) => {
+                tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEntity, (error2, result, response) => { // eslint-disable-line no-unused-vars
                     if(!error2){
                         FetchSiteDefinitions(siteDefinition.name, tableService, callback);
                     }else{

--- a/src/storageClients/AzureTableStorageManager.js
+++ b/src/storageClients/AzureTableStorageManager.js
@@ -201,7 +201,7 @@ module.exports = {
 
     InsertOrReplaceSiteDefinition(siteDefintion, callback){
         let tableService = azureStorage.createTableService();
-        const tableEnity = Object.assign({}, siteDefintion, {
+        const tableEntity = Object.assign({}, siteDefintion, {
             defaultLocation: JSON.stringify(siteDefintion.defaultLocation),
             targetBbox: JSON.stringify(siteDefintion.targetBbox),
             supportedLanguages: JSON.stringify(siteDefintion.supportedLanguages),
@@ -211,11 +211,11 @@ module.exports = {
 
         tableService.createTableIfNotExists(AZURE_TBL_SITES, (error, result, response) => { // eslint-disable-line no-unused-vars
             if(!error){
-                tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEnity, (error2, result, response) => { // eslint-disable-line no-unused-vars
+                 tableService.insertOrReplaceEntity(AZURE_TBL_SITES, tableEntity, (error2, result, response) => {
                     if(!error2){
                         FetchSiteDefinitions(siteDefintion.name, tableService, callback);
                     }else{
-                        callback(`There was an error writing to table [${AZURE_TBL_SITES}] with definition[${JSON.stringify(tableEnity)}]`);
+                        callback(`There was an error writing to table [${AZURE_TBL_SITES}] with definition[${JSON.stringify(tableEntity)}]`);
                     }
                 });
             }else{

--- a/src/storageClients/BlobStorageFactsManager.js
+++ b/src/storageClients/BlobStorageFactsManager.js
@@ -9,114 +9,114 @@ const FACTS_STORAGE_CONNECTION_STRING = process.env.FACTS_STORAGE_CONNECTION_STR
 
 module.exports = {
 
-    GetFact: function (id, callback, logger) { // eslint-disable-line no-unused-vars
-        var blobSvc = azure.createBlobService(FACTS_STORAGE_CONNECTION_STRING);
-        let blobPrefix = id.split('-')[0] + '/' + id.split('-')[1] + '/' + id.split('-')[2];
-        let factIndex = id.split('-')[3];
-        blobSvc.listBlobsSegmentedWithPrefix(FACTS_CONTAINER_NAME, blobPrefix, null, null, (error, result, response) => { // eslint-disable-line no-unused-vars
-            if (error || !result || !result.entries || result.entries.length == 0) {
-                callback(null, error);
+  GetFact: function (id, callback, logger) { // eslint-disable-line no-unused-vars
+    var blobSvc = azure.createBlobService(FACTS_STORAGE_CONNECTION_STRING);
+    let blobPrefix = id.split('-')[0] + '/' + id.split('-')[1] + '/' + id.split('-')[2];
+    let factIndex = id.split('-')[3];
+    blobSvc.listBlobsSegmentedWithPrefix(FACTS_CONTAINER_NAME, blobPrefix, null, null, (error, result, response) => { // eslint-disable-line no-unused-vars
+      if (error || !result || !result.entries || result.entries.length == 0) {
+        callback(null, error);
+      }
+      else {
+        let blobName = result.entries[0].name;
+        blobSvc.getBlobToText(FACTS_CONTAINER_NAME, blobName, null, function (error, text) {
+          if (error) {
+            callback(null, error);
+          }
+          else {
+            try {
+              let rawFact = JSON.parse(text.split('\n')[factIndex]);
+              callback(getFactObject(rawFact, blobName, factIndex));
             }
-            else {
-                let blobName = result.entries[0].name;
-                blobSvc.getBlobToText(FACTS_CONTAINER_NAME, blobName, null, function (error, text) {
-                    if (error) {
-                        callback(null, error);
-                    }
-                    else {
-                        try {
-                            let rawFact = JSON.parse(text.split('\n')[factIndex]);
-                            callback(getFactObject(rawFact, blobName, factIndex));
-                        }
                         catch (e) {
-                            callback(null, e);
+                          callback(null, e);
                         }
-                    }
-                });
-            }
+          }
         });
-    },
+      }
+    });
+  },
 
-    FetchFacts: function (pageSize, skip, tagFilter, callback, logger) {
-        pageSize = pageSize || DEFAULT_PAGE_SIZE;
-        skip = skip || DEFAULT_SKIP;
+  FetchFacts: function (pageSize, skip, tagFilter, callback, logger) {
+    pageSize = pageSize || DEFAULT_PAGE_SIZE;
+    skip = skip || DEFAULT_SKIP;
 
-        var blobSvc = azure.createBlobService(FACTS_STORAGE_CONNECTION_STRING);
-        new Promise((resolve, reject) => {
-            blobSvc.listBlobsSegmented(FACTS_CONTAINER_NAME, null, (error, result, response) => { // eslint-disable-line no-unused-vars
-                if (!error) {
-                    let blobs = result.entries.filter(blob => {
-                        return blob.name.indexOf('.json') != -1 && blob.lastModified;
-                    }).sort(function (a, b) {
-                        return Date.parse(getDateFromBlobName(a.name)) < Date.parse(getDateFromBlobName(b.name)) ? 1 : -1;
-                    }).slice(skip, skip + pageSize);
-                    resolve(blobs);
+    var blobSvc = azure.createBlobService(FACTS_STORAGE_CONNECTION_STRING);
+    new Promise((resolve, reject) => {
+      blobSvc.listBlobsSegmented(FACTS_CONTAINER_NAME, null, (error, result, response) => { // eslint-disable-line no-unused-vars
+        if (!error) {
+          let blobs = result.entries.filter(blob => {
+            return blob.name.indexOf('.json') != -1 && blob.lastModified;
+          }).sort(function (a, b) {
+            return Date.parse(getDateFromBlobName(a.name)) < Date.parse(getDateFromBlobName(b.name)) ? 1 : -1;
+          }).slice(skip, skip + pageSize);
+          resolve(blobs);
+        }
+        else {
+          console.log(`error [${error}]`);
+          reject(error);
+        }
+      });
+    }).then(blobs => {
+      Promise.all(getReadBlobPromises(blobs, tagFilter)).then(facts => {
+        var result = facts.filter(fact => fact).sort(function (a, b) {
+          return a.id < b.id ? 1 : -1;
+        }).slice(0, pageSize);
+        callback(result);
+      });
+    }).catch(error => callback(null, error));
+
+
+    function getReadBlobPromises(blobs, tagFilter) {
+      var blobReadPromises = [];
+      blobs.forEach(blob => {
+        blobReadPromises.push(new Promise((resolve, reject) => { // eslint-disable-line no-unused-vars
+          blobSvc.getBlobToText(FACTS_CONTAINER_NAME, blob.name, null, function (error, text) {
+            let factIndex = 0;
+            text.split('\n').forEach(factText => {
+              try {
+                let rawFact = JSON.parse(factText);
+                if (tagFilter && tagFilter.length != 0 && !tagsMatchFilter(tagFilter, rawFact.tags)) {
+                  resolve();
                 }
                 else {
-                    console.log(`error [${error}]`);
-                    reject(error);
+                  factIndex++;
+                  console.log(getFactObject(rawFact, blob.name));
+                  resolve(getFactObject(rawFact, blob.name, factIndex));
                 }
-            });
-        }).then(blobs => {
-            Promise.all(getReadBlobPromises(blobs, tagFilter)).then(facts => {
-                var result = facts.filter(fact => fact).sort(function (a, b) {
-                    return a.id < b.id ? 1 : -1;
-                }).slice(0, pageSize);
-                callback(result);
-            });
-        }).catch(error => callback(null, error));
 
-
-        function getReadBlobPromises(blobs, tagFilter) {
-            var blobReadPromises = [];
-            blobs.forEach(blob => {
-                blobReadPromises.push(new Promise((resolve, reject) => { // eslint-disable-line no-unused-vars
-                    blobSvc.getBlobToText(FACTS_CONTAINER_NAME, blob.name, null, function (error, text) {
-                        let factIndex = 0;
-                        text.split('\n').forEach(factText => {
-                            try {
-                                let rawFact = JSON.parse(factText);
-                                if (tagFilter && tagFilter.length != 0 && !tagsMatchFilter(tagFilter, rawFact.tags)) {
-                                    resolve();
-                                }
-                                else {
-                                    factIndex++;
-                                    console.log(getFactObject(rawFact, blob.name));
-                                    resolve(getFactObject(rawFact, blob.name, factIndex));
-                                }
-
-                            }
+              }
                             catch (e) {
-                                if (logger) logger(e);
-                                resolve();
+                              if (logger) logger(e);
+                              resolve();
                             }
 
-                        });
-                    });
-                }));
             });
-            return blobReadPromises;
-        }
+          });
+        }));
+      });
+      return blobReadPromises;
     }
+  }
 };
 
 function getDateFromBlobName(name) {
-    return name.split('/')[0] + '-' + name.split('/')[1] + '-' + name.split('/')[2];
+  return name.split('/')[0] + '-' + name.split('/')[1] + '-' + name.split('/')[2];
 }
 
 function tagsMatchFilter(tagFilter, factTags) {
-    return factTags.filter(factTag => tagFilter.indexOf(factTag) != -1).length != 0;
+  return factTags.filter(factTag => tagFilter.indexOf(factTag) != -1).length != 0;
 }
 
 function getFactObject(rawFact, blobName, factIndex) {
-    return {
-        id: getDateFromBlobName(blobName) + '-' + factIndex,
-        language: rawFact.language,
-        title: rawFact.title,
-        tags: rawFact.tags,
-        date: getDateFromBlobName(blobName),
-        sources: rawFact.sources,
-        text: rawFact.text,
-        link: rawFact.link
-    };
+  return {
+    id: getDateFromBlobName(blobName) + '-' + factIndex,
+    language: rawFact.language,
+    title: rawFact.title,
+    tags: rawFact.tags,
+    date: getDateFromBlobName(blobName),
+    sources: rawFact.sources,
+    text: rawFact.text,
+    link: rawFact.link
+  };
 }

--- a/src/storageClients/BlobStorageManager.js
+++ b/src/storageClients/BlobStorageManager.js
@@ -1,7 +1,9 @@
 "use strict"
 
-let azure = require('azure-storage');
-let Promise = require('promise');
+//can i take the promise off here? below
+var Promise = require("bluebird");
+
+const azure = Promise.promisifyAll(require('azure-storage'));
 
 //TODO: remove hardcoded const values:
 const CONTAINER_NAME = "settings";
@@ -9,62 +11,33 @@ const CONTAINER_STORAGE_CONNECTION_STRING = "DefaultEndpointsProtocol=https;Acco
 
 module.exports = {
 
-  //!!!!TODO: https://softwareengineering.stackexchange.com/questions/144326/try-catch-in-javascript-isnt-it-a-good-practice
-  // should i return null or {} when I don't get back anything from the get and theres no error? ill return null for now
   Get: function(containerName, blobName, id) {
-    let blobSvc = azure.createBlobService(CONTAINER_STORAGE_CONNECTION_STRING); //TODO: error handle if conn str not provided
+    let blobSvc = azure.createBlobService(CONTAINER_STORAGE_CONNECTION_STRING);
     return new Promise((resolve, reject) => {
-      blobSvc.listBlobsSegmentedWithPrefix(containerName,"",null,null,(err, result) => {
-        if (err || !result || !result.entries || result.entries.length == 0) {
+      blobSvc.getBlobToTextAsync(containerName, blobName, null)
+        .then(text => {
+          resolve(JSON.parse(text)[id]);
+        })
+        .catch(err => {
           reject(err);
-        } else {
-          blobSvc.getBlobToText(containerName, blobName, null, function (error, text) {
-            if (error) {
-              callback(error, null);
-            } else {
-              try {
-                let item = JSON.parse(text)[id];
-                console.log("item: ", item);
-                resolve(item);
-              } catch (e) {
-                callback(e, null);
-              }
-            }
-          });
-        }
-      });
+        });
     });
   },
 
-  //TODO:
-  Fetch: function (pageSize, skip, tagFilter, callback, logger) {
-          pageSize = pageSize || DEFAULT_PAGE_SIZE;
-          skip = skip || DEFAULT_SKIP;
-
-          var blobSvc = azure.createBlobService(FACTS_STORAGE_CONNECTION_STRING);
-          new Promise((resolve, reject) => {
-              blobSvc.listBlobsSegmented(FACTS_CONTAINER_NAME, null, (error, result, response) => {
-                  if (!error) {
-                      let blobs = result.entries.filter(blob => {
-                          return blob.name.indexOf(".json") != -1 && blob.lastModified;
-                      }).sort(function (a, b) {
-                          return Date.parse(getDateFromBlobName(a.name)) < Date.parse(getDateFromBlobName(b.name)) ? 1 : -1;
-                      }).slice(skip, skip + pageSize);
-                      resolve(blobs);
-                  }
-                  else {
-                      console.log(`error [${error}]`);
-                      reject(error);
-                  }
-              });
-          }).then(blobs => {
-              Promise.all(getReadBlobPromises(blobs, tagFilter)).then(facts => {
-                  var result = facts.filter(fact => fact).sort(function (a, b) {
-                      return a.id < b.id ? 1 : -1;
-                  }).slice(0, pageSize);
-                  callback(result);
-              });
-          }).catch(error => callback(null, error));
-   }
+  List: function(containerName, blobName) {
+    let blobSvc = azure.createBlobService(CONTAINER_STORAGE_CONNECTION_STRING);
+    return new Promise((resolve, reject) => {
+      blobSvc.getBlobToTextAsync(containerName, blobName, null)
+        .then(text => {
+          return JSON.parse(text);
+        })
+        .then(list => {
+          resolve({'collection': list});
+        })
+        .catch(err => {
+          reject(err);
+        });
+    });
+  }
 
 }

--- a/src/storageClients/BlobStorageManager.js
+++ b/src/storageClients/BlobStorageManager.js
@@ -4,86 +4,72 @@ const Promise = require('bluebird');
 const azure = Promise.promisifyAll(require('azure-storage'));
 
 const BLOB_STORAGE_CONNECTION_STRING = process.env.BLOB_STORAGE_CONNECTION_STRING;
+const TOPIC_SEED_CONTAINER = process.env.TOPIC_SEED_CONTAINER;
 
 module.exports = {
 
-  Get: function(containerName, blobName, id) {
+  Get: (blobName, id) => {
     let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
     return new Promise((resolve, reject) => {
-      blobSvc.getBlobToTextAsync(containerName, blobName, null)
+      blobSvc.getBlobToTextAsync(TOPIC_SEED_CONTAINER, blobName, null)
+        .then(JSON.parse)
         .then(text => {
-          let item = JSON.parse(text)[id];
-          if(item) {
-            resolve(JSON.parse(text)[id]);
-          } else {
-            resolve(null);
-          }
+          let item = text[id];
+          if (item) resolve(item);
+          else reject(null);
         })
-        .catch(err => {
-          reject(err);
-        });
+        .catch(reject);
     });
   },
 
-  List: function(containerName, blobNames) {
+  List: blobNames => {
     return new Promise((resolve, reject) => {
-      Promise.all(getListPromises(containerName, blobNames))
+      Promise.all(getListPromises(blobNames))
         .then(itemsArrays => {
-          let mergedItems = [].concat.apply([], itemsArrays);
-          let list = {'collection': mergedItems};
-          resolve(list);
+          resolve({'collection': flatten(itemsArrays)});
         })
-        .catch(err => {
-          reject(err);
-        });
+        .catch(reject);
     });
   },
 
-  getBlobNamesWithSiteType: function(containerName, siteType) {
+  getBlobNamesWithSiteType: siteType => {
     return new Promise((resolve, reject) => {
-      listBlobsInContainer(containerName)
+      listBlobsInContainer()
         .then(blobNames => {
-          blobNames = blobNames.filter(blobNames => (blobNames.indexOf(siteType) > -1));
+          blobNames = blobNames.filter(blobName => (blobName.indexOf(siteType) > -1));
           resolve(blobNames);
         })
-        .catch(err => {
-          reject(err);
-        });
+        .catch(reject);
     });
   }
 
 };
 
-let getListPromises = (containerName, blobNames) => {
+let flatten = arrayOfArrays => [].concat.apply([], arrayOfArrays);
+
+let getListPromises = blobNames => {
   let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
   let listPromises = [];
-  for ( let blobName of blobNames ) {
+  blobNames.map(blobName => {
     listPromises.push(
       new Promise((resolve, reject) => {
-        blobSvc.getBlobToTextAsync(containerName, blobName, null)
+        blobSvc.getBlobToTextAsync(TOPIC_SEED_CONTAINER, blobName, null)
           .then(JSON.parse)
-          .then(list => {
-            resolve(list);
-          })
-          .catch(err => {
-            reject(err);
-          });
+          .then(resolve)
+          .catch(reject);
       })
     );
-  }
+  });
   return listPromises;
 };
 
-let listBlobsInContainer = containerName => {
+let listBlobsInContainer = () => {
   let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
   return new Promise((resolve, reject) => {
-    blobSvc.listBlobsSegmentedAsync(containerName, null)
+    blobSvc.listBlobsSegmentedAsync(TOPIC_SEED_CONTAINER, null)
       .then(blobs => {
-        blobs.entries = blobs.entries.map(blob => blob.name);
-        resolve(blobs.entries);
+        resolve(blobs.entries.map(blob => blob.name));
       })
-      .catch(err => {
-        reject(err);
-      });
+      .catch(reject);
   });
 };

--- a/src/storageClients/BlobStorageManager.js
+++ b/src/storageClients/BlobStorageManager.js
@@ -26,7 +26,6 @@ module.exports = {
     },
 
     List: function(containerName, blobNames) {
-        let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
         return new Promise((resolve, reject) => {
             Promise.all(getListPromises(containerName, blobNames))
         .then(itemsArrays => {

--- a/src/storageClients/BlobStorageManager.js
+++ b/src/storageClients/BlobStorageManager.js
@@ -1,0 +1,70 @@
+"use strict"
+
+let azure = require('azure-storage');
+let Promise = require('promise');
+
+//TODO: remove hardcoded const values:
+const CONTAINER_NAME = "settings";
+const CONTAINER_STORAGE_CONNECTION_STRING = "DefaultEndpointsProtocol=https;AccountName=fortiscentral;AccountKey=Vwbsz5N5rvGJc9eXjmqbkD20yFod4CaNa131pQf2o5Els3xsEzYo4UI4nl2KaBypNMLBlHXewJPWYEVghSICCg==;EndpointSuffix=core.windows.net";
+
+module.exports = {
+
+  //!!!!TODO: https://softwareengineering.stackexchange.com/questions/144326/try-catch-in-javascript-isnt-it-a-good-practice
+  // should i return null or {} when I don't get back anything from the get and theres no error? ill return null for now
+  Get: function(containerName, blobName, id) {
+    let blobSvc = azure.createBlobService(CONTAINER_STORAGE_CONNECTION_STRING); //TODO: error handle if conn str not provided
+    return new Promise((resolve, reject) => {
+      blobSvc.listBlobsSegmentedWithPrefix(containerName,"",null,null,(err, result) => {
+        if (err || !result || !result.entries || result.entries.length == 0) {
+          reject(err);
+        } else {
+          blobSvc.getBlobToText(containerName, blobName, null, function (error, text) {
+            if (error) {
+              callback(error, null);
+            } else {
+              try {
+                let item = JSON.parse(text)[id];
+                console.log("item: ", item);
+                resolve(item);
+              } catch (e) {
+                callback(e, null);
+              }
+            }
+          });
+        }
+      });
+    });
+  },
+
+  //TODO:
+  Fetch: function (pageSize, skip, tagFilter, callback, logger) {
+          pageSize = pageSize || DEFAULT_PAGE_SIZE;
+          skip = skip || DEFAULT_SKIP;
+
+          var blobSvc = azure.createBlobService(FACTS_STORAGE_CONNECTION_STRING);
+          new Promise((resolve, reject) => {
+              blobSvc.listBlobsSegmented(FACTS_CONTAINER_NAME, null, (error, result, response) => {
+                  if (!error) {
+                      let blobs = result.entries.filter(blob => {
+                          return blob.name.indexOf(".json") != -1 && blob.lastModified;
+                      }).sort(function (a, b) {
+                          return Date.parse(getDateFromBlobName(a.name)) < Date.parse(getDateFromBlobName(b.name)) ? 1 : -1;
+                      }).slice(skip, skip + pageSize);
+                      resolve(blobs);
+                  }
+                  else {
+                      console.log(`error [${error}]`);
+                      reject(error);
+                  }
+              });
+          }).then(blobs => {
+              Promise.all(getReadBlobPromises(blobs, tagFilter)).then(facts => {
+                  var result = facts.filter(fact => fact).sort(function (a, b) {
+                      return a.id < b.id ? 1 : -1;
+                  }).slice(0, pageSize);
+                  callback(result);
+              });
+          }).catch(error => callback(null, error));
+   }
+
+}

--- a/src/storageClients/BlobStorageManager.js
+++ b/src/storageClients/BlobStorageManager.js
@@ -1,90 +1,90 @@
-"use strict"
+'use strict';
 
-const Promise = require("bluebird");
+const Promise = require('bluebird');
 const azure = Promise.promisifyAll(require('azure-storage'));
 
 const BLOB_STORAGE_CONNECTION_STRING = process.env.BLOB_STORAGE_CONNECTION_STRING;
 
 module.exports = {
 
-  Get: function(containerName, blobName, id) {
-    let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
-    return new Promise((resolve, reject) => {
-      blobSvc.getBlobToTextAsync(containerName, blobName, null)
+    Get: function(containerName, blobName, id) {
+        let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
+        return new Promise((resolve, reject) => {
+            blobSvc.getBlobToTextAsync(containerName, blobName, null)
         .then(text => {
-          let item = JSON.parse(text)[id];
-          if(item) {
-            resolve(JSON.parse(text)[id]);
-          } else {
-            resolve(null);
-          }
+            let item = JSON.parse(text)[id];
+            if(item) {
+                resolve(JSON.parse(text)[id]);
+            } else {
+                resolve(null);
+            }
         })
         .catch(err => {
-          reject(err);
+            reject(err);
         });
-    });
-  },
+        });
+    },
 
-  List: function(containerName, blobNames) {
-    let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
-    return new Promise((resolve, reject) => {
-      Promise.all(getListPromises(containerName, blobNames))
+    List: function(containerName, blobNames) {
+        let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
+        return new Promise((resolve, reject) => {
+            Promise.all(getListPromises(containerName, blobNames))
         .then(itemsArrays => {
-          let mergedItems = [].concat.apply([], itemsArrays);
-          let list = {'collection': mergedItems};
-          resolve(list);
+            let mergedItems = [].concat.apply([], itemsArrays);
+            let list = {'collection': mergedItems};
+            resolve(list);
         })
         .catch(err => {
-          reject(err);
+            reject(err);
         });
-    });
-  },
+        });
+    },
 
-  getBlobNamesWithSiteType: function(containerName, siteType) {
-    return new Promise((resolve, reject) => {
-      listBlobsInContainer(containerName)
+    getBlobNamesWithSiteType: function(containerName, siteType) {
+        return new Promise((resolve, reject) => {
+            listBlobsInContainer(containerName)
         .then(blobNames => {
-          blobNames = blobNames.filter(blobNames => (blobNames.indexOf(siteType) > -1));
-          resolve(blobNames);
+            blobNames = blobNames.filter(blobNames => (blobNames.indexOf(siteType) > -1));
+            resolve(blobNames);
         })
         .catch(err => {
-          reject(err);
+            reject(err);
         });
-    });
-  }
+        });
+    }
 
-}
+};
 
 let getListPromises = (containerName, blobNames) => {
-  let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
-  let listPromises = [];
-  for ( let blobName of blobNames ) {
-    listPromises.push(
+    let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
+    let listPromises = [];
+    for ( let blobName of blobNames ) {
+        listPromises.push(
       new Promise((resolve, reject) => {
-        blobSvc.getBlobToTextAsync(containerName, blobName, null)
+          blobSvc.getBlobToTextAsync(containerName, blobName, null)
           .then(JSON.parse)
           .then(list => {
-            resolve(list);
+              resolve(list);
           })
           .catch(err => {
-            reject(err);
+              reject(err);
           });
       })
     );
-  }
-  return listPromises;
-}
+    }
+    return listPromises;
+};
 
 let listBlobsInContainer = containerName => {
-  let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
-  return new Promise((resolve, reject) => {
-    blobSvc.listBlobsSegmentedAsync(containerName, null)
+    let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
+    return new Promise((resolve, reject) => {
+        blobSvc.listBlobsSegmentedAsync(containerName, null)
       .then(blobs => {
-        blobs.entries = blobs.entries.map(blob => blob.name);
-        resolve(blobs.entries);
+          blobs.entries = blobs.entries.map(blob => blob.name);
+          resolve(blobs.entries);
       })
       .catch(err => {
-        reject(err);
+          reject(err);
       });
-  });
-}
+    });
+};

--- a/src/storageClients/BlobStorageManager.js
+++ b/src/storageClients/BlobStorageManager.js
@@ -7,83 +7,83 @@ const BLOB_STORAGE_CONNECTION_STRING = process.env.BLOB_STORAGE_CONNECTION_STRIN
 
 module.exports = {
 
-    Get: function(containerName, blobName, id) {
-        let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
-        return new Promise((resolve, reject) => {
-            blobSvc.getBlobToTextAsync(containerName, blobName, null)
+  Get: function(containerName, blobName, id) {
+    let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
+    return new Promise((resolve, reject) => {
+      blobSvc.getBlobToTextAsync(containerName, blobName, null)
         .then(text => {
-            let item = JSON.parse(text)[id];
-            if(item) {
-                resolve(JSON.parse(text)[id]);
-            } else {
-                resolve(null);
-            }
+          let item = JSON.parse(text)[id];
+          if(item) {
+            resolve(JSON.parse(text)[id]);
+          } else {
+            resolve(null);
+          }
         })
         .catch(err => {
-            reject(err);
+          reject(err);
         });
-        });
-    },
+    });
+  },
 
-    List: function(containerName, blobNames) {
-        return new Promise((resolve, reject) => {
-            Promise.all(getListPromises(containerName, blobNames))
+  List: function(containerName, blobNames) {
+    return new Promise((resolve, reject) => {
+      Promise.all(getListPromises(containerName, blobNames))
         .then(itemsArrays => {
-            let mergedItems = [].concat.apply([], itemsArrays);
-            let list = {'collection': mergedItems};
-            resolve(list);
+          let mergedItems = [].concat.apply([], itemsArrays);
+          let list = {'collection': mergedItems};
+          resolve(list);
         })
         .catch(err => {
-            reject(err);
+          reject(err);
         });
-        });
-    },
+    });
+  },
 
-    getBlobNamesWithSiteType: function(containerName, siteType) {
-        return new Promise((resolve, reject) => {
-            listBlobsInContainer(containerName)
+  getBlobNamesWithSiteType: function(containerName, siteType) {
+    return new Promise((resolve, reject) => {
+      listBlobsInContainer(containerName)
         .then(blobNames => {
-            blobNames = blobNames.filter(blobNames => (blobNames.indexOf(siteType) > -1));
-            resolve(blobNames);
+          blobNames = blobNames.filter(blobNames => (blobNames.indexOf(siteType) > -1));
+          resolve(blobNames);
         })
         .catch(err => {
-            reject(err);
+          reject(err);
         });
-        });
-    }
+    });
+  }
 
 };
 
 let getListPromises = (containerName, blobNames) => {
-    let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
-    let listPromises = [];
-    for ( let blobName of blobNames ) {
-        listPromises.push(
+  let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
+  let listPromises = [];
+  for ( let blobName of blobNames ) {
+    listPromises.push(
       new Promise((resolve, reject) => {
-          blobSvc.getBlobToTextAsync(containerName, blobName, null)
+        blobSvc.getBlobToTextAsync(containerName, blobName, null)
           .then(JSON.parse)
           .then(list => {
-              resolve(list);
+            resolve(list);
           })
           .catch(err => {
-              reject(err);
+            reject(err);
           });
       })
     );
-    }
-    return listPromises;
+  }
+  return listPromises;
 };
 
 let listBlobsInContainer = containerName => {
-    let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
-    return new Promise((resolve, reject) => {
-        blobSvc.listBlobsSegmentedAsync(containerName, null)
+  let blobSvc = azure.createBlobService(BLOB_STORAGE_CONNECTION_STRING);
+  return new Promise((resolve, reject) => {
+    blobSvc.listBlobsSegmentedAsync(containerName, null)
       .then(blobs => {
-          blobs.entries = blobs.entries.map(blob => blob.name);
-          resolve(blobs.entries);
+        blobs.entries = blobs.entries.map(blob => blob.name);
+        resolve(blobs.entries);
       })
       .catch(err => {
-          reject(err);
+        reject(err);
       });
-    });
+  });
 };

--- a/src/storageClients/CassandraTableStorageManager.js
+++ b/src/storageClients/CassandraTableStorageManager.js
@@ -6,43 +6,43 @@ const BATCH_LIMIT = 10;
 
 module.exports = {
 
-    prepareInsertTopic: function(topic) { //TODO: the insert statement to reflect the final topic schema
-        return {
-            query: 'INSERT INTO topics (id, topic, value) VALUES (?, ?, ?)',
-            params: [ topic.id, topic.topic, topic.value ]
-        };
-    },
+  prepareInsertTopic: function(topic) { //TODO: the insert statement to reflect the final topic schema
+    return {
+      query: 'INSERT INTO topics (id, topic, value) VALUES (?, ?, ?)',
+      params: [ topic.id, topic.topic, topic.value ]
+    };
+  },
 
-    batch: function(client, queries){
-        return new Promise((resolve, reject) => {
-            Promise.all(getBatchPromises(client, queries))
+  batch: function(client, queries){
+    return new Promise((resolve, reject) => {
+      Promise.all(getBatchPromises(client, queries))
         .then(res => {
-            resolve(res);
+          resolve(res);
         })
         .catch(err => {
-            reject(err);
+          reject(err);
         });
-        });
-    }
+    });
+  }
 
 };
 
 let getBatchPromises = (client, queries) => {
-    let insertPromises = [];
-    for ( let i = 0, j = queries.length; i < j; i += BATCH_LIMIT ) {
-        insertPromises.push(
+  let insertPromises = [];
+  for ( let i = 0, j = queries.length; i < j; i += BATCH_LIMIT ) {
+    insertPromises.push(
       new Promise((resolve, reject) => {
-          client.batch(queries.slice(i, i + BATCH_LIMIT), { prepare: true })
+        client.batch(queries.slice(i, i + BATCH_LIMIT), { prepare: true })
           .then(res => {
-              resolve(res);
+            resolve(res);
           })
           .catch(err => {
-              reject(err);
+            reject(err);
           });
       })
     );
-    }
-    return insertPromises;
+  }
+  return insertPromises;
 };
 
 

--- a/src/storageClients/CassandraTableStorageManager.js
+++ b/src/storageClients/CassandraTableStorageManager.js
@@ -55,11 +55,6 @@ Add app insights for reporting errors:
 Connecting to cassandra
 Failed storage mutations
 
-unit test with mocha
-and
-sinon
-  use mocks for connections to cassandra
-
 Disconnect from cassandra on error
 */
 

--- a/src/storageClients/CassandraTableStorageManager.js
+++ b/src/storageClients/CassandraTableStorageManager.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const cassandraConnector = require('../connectors/CassandraConnector');
 const Promise = require('bluebird');
 
 const BATCH_LIMIT = 10;

--- a/src/storageClients/CassandraTableStorageManager.js
+++ b/src/storageClients/CassandraTableStorageManager.js
@@ -6,43 +6,33 @@ const BATCH_LIMIT = 10;
 
 module.exports = {
 
-  prepareInsertTopic: function(topic) { //TODO: the insert statement to reflect the final topic schema
+  prepareInsertTopic: topic => { //TODO: the insert statement to reflect the final topic schema
     return {
       query: 'INSERT INTO topics (id, topic, value) VALUES (?, ?, ?)',
       params: [ topic.id, topic.topic, topic.value ]
     };
   },
 
-  batch: function(client, queries){
+  batch: (client, queries) => {
     return new Promise((resolve, reject) => {
-      Promise.all(getBatchPromises(client, queries))
-        .then(res => {
-          resolve(res);
-        })
-        .catch(err => {
-          reject(err);
-        });
+      Promise.all(chunkQueryPromises(client, queries, BATCH_LIMIT))
+        .then(resolve)
+        .catch(reject);
     });
   }
 
 };
 
-let getBatchPromises = (client, queries) => {
-  let insertPromises = [];
-  for ( let i = 0, j = queries.length; i < j; i += BATCH_LIMIT ) {
-    insertPromises.push(
+let chunkQueryPromises = (client, array, chunkSize) => {
+  let promises = [];
+  for ( let i = 0, j = array.length; i < j; i += chunkSize ) {
+    promises.push(
       new Promise((resolve, reject) => {
-        client.batch(queries.slice(i, i + BATCH_LIMIT), { prepare: true })
-          .then(res => {
-            resolve(res);
-          })
-          .catch(err => {
-            reject(err);
-          });
+        client.batch(array.slice(i, i + chunkSize), { prepare: true })
+          .then(resolve)
+          .catch(reject);
       })
     );
   }
-  return insertPromises;
+  return promises;
 };
-
-

--- a/src/storageClients/CassandraTableStorageManager.js
+++ b/src/storageClients/CassandraTableStorageManager.js
@@ -1,0 +1,67 @@
+"use strict"
+
+let asyncEachLimit = require('async/eachLimit');
+const ASYNC_INSERT_LIMIT = 10;
+
+const cassandraConnector = require("../connectors/CassandraConnector");
+
+const CONTACT_POINTS = ['h1','h2'];
+const KEYSPACE = 'ks1';
+
+function processInsert(client, siteType, item, asyncCB) {
+  const query = `INSERT INTO Topics (id, name, value) VALUES (?, ?, ?)`;
+  const params = [ 1, "humanitarian aid", siteType ];
+
+  // 1
+  client.execute(query, params, { prepare: true })
+    .then(result => console.log('inserted row with ' + params[0] + params[1] + params[2]));
+
+  // 2
+  const queries = [
+    {
+      query: 'UPDATE user_profiles SET email=? WHERE key=?',
+      params: [ emailAddress, 'hendrix' ]
+    },
+    {
+      query: 'INSERT INTO user_track (key, text, date) VALUES (?, ?, ?)',
+      params: [ 'hendrix', 'Changed email', new Date() ]
+    }
+  ];
+  client.batch(queries, { prepare: true })
+    .then(result => console.log('Data updated on cluster'));
+}
+
+module.exports = {
+  //TODO: can I generalize this beyond topics?
+  insert: function(siteType, items){
+    const client = cassandraConnector.getClient(CONTACT_POINTS, KEYSPACE);
+
+    /*if db only allows a limited number of connections at a time*/
+    asyncEachLimit(items, ASYNC_INSERT_LIMIT, (siteType, item, asyncCB) => processInsert(client, siteType, item, asyncCB), finalCBErr => {
+      let processedInserts;
+      if(finalCBErr){
+        console.error(`Error occured inserting items into Topics table: ${JSON.stringify(finalCBErr)}`);
+      }else{
+        console.log(`Finished writing ${items.length} to Topics table`);
+        processedInserts = items.map(item => item.RowKey);
+      }
+        callback(finalCBErr, processedInserts);
+    });
+  }
+}
+
+/* TODO ***********************************
+Add app insights for reporting errors:
+Connecting to cassandra
+Failed storage mutations
+
+unit test with mocha
+and
+sinon
+  use mocks for connections to cassandra
+
+Disconnect from cassandra on error
+*/
+
+//let appInsights = require("applicationinsights");
+//let appInsightsClient = appInsights.getClient();

--- a/src/storageClients/CassandraTableStorageManager.js
+++ b/src/storageClients/CassandraTableStorageManager.js
@@ -1,49 +1,49 @@
-'use strict'
+'use strict';
 
-const cassandraConnector = require("../connectors/CassandraConnector");
-const Promise = require("bluebird");
+const cassandraConnector = require('../connectors/CassandraConnector');
+const Promise = require('bluebird');
 
 const BATCH_LIMIT = 10;
 
 module.exports = {
 
-  prepareInsertTopic: function(topic) { //TODO: the insert statement to reflect the final topic schema
-    return {
-      query: 'INSERT INTO topics (id, topic, value) VALUES (?, ?, ?)',
-      params: [ topic.id, topic.topic, topic.value ]
-    };
-  },
+    prepareInsertTopic: function(topic) { //TODO: the insert statement to reflect the final topic schema
+        return {
+            query: 'INSERT INTO topics (id, topic, value) VALUES (?, ?, ?)',
+            params: [ topic.id, topic.topic, topic.value ]
+        };
+    },
 
-  batch: function(client, queries){
-    return new Promise((resolve, reject) => {
-      Promise.all(getBatchPromises(client, queries))
+    batch: function(client, queries){
+        return new Promise((resolve, reject) => {
+            Promise.all(getBatchPromises(client, queries))
         .then(res => {
-          resolve(res);
+            resolve(res);
         })
         .catch(err => {
-          reject(err);
+            reject(err);
         });
-    });
-  }
+        });
+    }
 
-}
+};
 
 let getBatchPromises = (client, queries) => {
-  let insertPromises = [];
-  for ( let i = 0, j = queries.length; i < j; i += BATCH_LIMIT ) {
-    insertPromises.push(
+    let insertPromises = [];
+    for ( let i = 0, j = queries.length; i < j; i += BATCH_LIMIT ) {
+        insertPromises.push(
       new Promise((resolve, reject) => {
-        client.batch(queries.slice(i, i + BATCH_LIMIT), { prepare: true })
+          client.batch(queries.slice(i, i + BATCH_LIMIT), { prepare: true })
           .then(res => {
-            resolve(res);
+              resolve(res);
           })
           .catch(err => {
-            reject(err);
+              reject(err);
           });
       })
     );
-  }
-  return insertPromises;
-}
+    }
+    return insertPromises;
+};
 
 

--- a/src/translatorClient/MsftTranslator.js
+++ b/src/translatorClient/MsftTranslator.js
@@ -61,7 +61,6 @@ function TranslateSentenceArray(access_token, wordsToTranslate, fromLanguage, to
 
     const text = `<Texts>${wordsToTranslate.map(text=>`<string xmlns='http://schemas.microsoft.com/2003/10/Serialization/Arrays'>${text}</string>`).join('')}</Texts>`;
     const requestXML = `<TranslateArrayRequest><AppId/><From>${fromLanguage}</From>${text}<To>${toLanguage}</To></TranslateArrayRequest>`;
-
     const POST = {
         url: translator_array_uri,
         headers: headers,

--- a/src/translatorClient/MsftTranslator.js
+++ b/src/translatorClient/MsftTranslator.js
@@ -12,133 +12,133 @@ const translator_uri = 'http://api.microsofttranslator.com/V2/Http.svc/Translate
 const translator_array_uri = 'http://api.microsofttranslator.com/V2/Http.svc/TranslateArray';
 
 function TranslatorAccessTokenExpired() {
-    let translatorToken = memoryStore.get('translatorToken');
-    if (translatorToken && translatorToken.expires > Date.now()) {
-        console.log('token missing/expired');
-        return false;
-    }else{
-        return true;
-    }
+  let translatorToken = memoryStore.get('translatorToken');
+  if (translatorToken && translatorToken.expires > Date.now()) {
+    console.log('token missing/expired');
+    return false;
+  }else{
+    return true;
+  }
 }
 
 function getAccessTokenForTranslation() {
-    const grant_type = 'client_credentials';
-    const now = new Date();
+  const grant_type = 'client_credentials';
+  const now = new Date();
 
-    const payload = {
-        client_id: client_id,
-        client_secret: client_secret,
-        scope: translator_scope,
-        grant_type: grant_type
-    };
+  const payload = {
+    client_id: client_id,
+    client_secret: client_secret,
+    scope: translator_scope,
+    grant_type: grant_type
+  };
 
-    const POST = {
-        url: datamarket_auth_uri,
-        form: payload
-    };
+  const POST = {
+    url: datamarket_auth_uri,
+    form: payload
+  };
 
-    return new Promise((resolve, reject) => {
-        request.post(POST, (err, response, body) => {
-            if (response.statusCode !== 200 || err) {
-                reject(err);
-            }
-            else {
-                body = JSON.parse(body);
-                resolve({
-                    'token': body.access_token,
-                    'expires': new Date(now.getTime() + parseInt(body.expires_in - 1) * 1000)
-                });
-            }
+  return new Promise((resolve, reject) => {
+    request.post(POST, (err, response, body) => {
+      if (response.statusCode !== 200 || err) {
+        reject(err);
+      }
+      else {
+        body = JSON.parse(body);
+        resolve({
+          'token': body.access_token,
+          'expires': new Date(now.getTime() + parseInt(body.expires_in - 1) * 1000)
         });
+      }
     });
+  });
 }
 
 function TranslateSentenceArray(access_token, wordsToTranslate, fromLanguage, toLanguage) {
-    const headers = {
-        'Authorization': 'Bearer ' + access_token,
-        'Content-Type':'text/xml; charset=utf-8'
-    };
+  const headers = {
+    'Authorization': 'Bearer ' + access_token,
+    'Content-Type':'text/xml; charset=utf-8'
+  };
 
-    const text = `<Texts>${wordsToTranslate.map(text=>`<string xmlns='http://schemas.microsoft.com/2003/10/Serialization/Arrays'>${text}</string>`).join('')}</Texts>`;
-    const requestXML = `<TranslateArrayRequest><AppId/><From>${fromLanguage}</From>${text}<To>${toLanguage}</To></TranslateArrayRequest>`;
-    const POST = {
-        url: translator_array_uri,
-        headers: headers,
-        body: requestXML
-    };
-    return new Promise((resolve, reject) => {
-        request.post(POST, (err, response, body) => {
-            if (err || !response || response.statusCode !== 200) {
-                reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
-            }
-            else {
-                xml2js.parseString(body, (err, result) => {
-                    if (!err & !!result && result.ArrayOfTranslateArrayResponse && result.ArrayOfTranslateArrayResponse.TranslateArrayResponse) {
-                        const translatedPhrases = result.ArrayOfTranslateArrayResponse.TranslateArrayResponse;
-                        resolve(wordsToTranslate.map((phrase, index)=>Object.assign({}, {originalSentence: phrase, translatedSentence: translatedPhrases[index].TranslatedText})));
-                    } else {
-                        reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
-                    }
-                });
-            }
+  const text = `<Texts>${wordsToTranslate.map(text=>`<string xmlns='http://schemas.microsoft.com/2003/10/Serialization/Arrays'>${text}</string>`).join('')}</Texts>`;
+  const requestXML = `<TranslateArrayRequest><AppId/><From>${fromLanguage}</From>${text}<To>${toLanguage}</To></TranslateArrayRequest>`;
+  const POST = {
+    url: translator_array_uri,
+    headers: headers,
+    body: requestXML
+  };
+  return new Promise((resolve, reject) => {
+    request.post(POST, (err, response, body) => {
+      if (err || !response || response.statusCode !== 200) {
+        reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
+      }
+      else {
+        xml2js.parseString(body, (err, result) => {
+          if (!err & !!result && result.ArrayOfTranslateArrayResponse && result.ArrayOfTranslateArrayResponse.TranslateArrayResponse) {
+            const translatedPhrases = result.ArrayOfTranslateArrayResponse.TranslateArrayResponse;
+            resolve(wordsToTranslate.map((phrase, index)=>Object.assign({}, {originalSentence: phrase, translatedSentence: translatedPhrases[index].TranslatedText})));
+          } else {
+            reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
+          }
         });
+      }
     });
+  });
 }
 
 function TranslateSentence(access_token, sentence, fromLanguage, toLanguage) {
-    var payload = { text: sentence, to: toLanguage, from: fromLanguage };
-    var headers = { Authorization: 'Bearer ' + access_token };
+  var payload = { text: sentence, to: toLanguage, from: fromLanguage };
+  var headers = { Authorization: 'Bearer ' + access_token };
 
-    var options = {
-        url: translator_uri,
-        headers: headers,
-        qs: payload
-    };
-    return new Promise((resolve, reject) => {
-        request(options, function (err, response, body) {
-            if (err || !response || response.statusCode !== 200) {
-                reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
-            }
-            else {
-                xml2js.parseString(body, (err, result) => {
-                    if (!err & !!result && !!result['string'] && !!result['string']['_']) {
-                        resolve(result['string']['_']);
-                    } else {
-                        reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
-                    }
-                });
-            }
+  var options = {
+    url: translator_uri,
+    headers: headers,
+    qs: payload
+  };
+  return new Promise((resolve, reject) => {
+    request(options, function (err, response, body) {
+      if (err || !response || response.statusCode !== 200) {
+        reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
+      }
+      else {
+        xml2js.parseString(body, (err, result) => {
+          if (!err & !!result && !!result['string'] && !!result['string']['_']) {
+            resolve(result['string']['_']);
+          } else {
+            reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
+          }
         });
+      }
     });
+  });
 }
 
 module.exports = {
-    translateSentenceArray: function(wordsToTranslate, fromLanguage, toLanguage) {
-        return new Promise((resolve, reject) => {
-            if (!TranslatorAccessTokenExpired()) {
-                TranslateSentenceArray(memoryStore.get('translatorToken').token, wordsToTranslate, fromLanguage, toLanguage).then(
+  translateSentenceArray: function(wordsToTranslate, fromLanguage, toLanguage) {
+    return new Promise((resolve, reject) => {
+      if (!TranslatorAccessTokenExpired()) {
+        TranslateSentenceArray(memoryStore.get('translatorToken').token, wordsToTranslate, fromLanguage, toLanguage).then(
                     result => resolve({ translatedSentence: result }), error => reject(error));
-            } else {
-                getAccessTokenForTranslation().then(authBody => {
-                    memoryStore.set('translatorToken', authBody);
-                    TranslateSentenceArray(authBody.token, wordsToTranslate, fromLanguage, toLanguage).then(
+      } else {
+        getAccessTokenForTranslation().then(authBody => {
+          memoryStore.set('translatorToken', authBody);
+          TranslateSentenceArray(authBody.token, wordsToTranslate, fromLanguage, toLanguage).then(
                         result => resolve({ translatedSentence: result }), error => reject(error));
-                }, error => reject(error));
-            }
-        });
-    },
-    translate: function(sentence, fromLanguage, toLanguage) {
-        return new Promise((resolve, reject) => {
-            if (!TranslatorAccessTokenExpired()) {
-                TranslateSentence(memoryStore.get('translatorToken').token, sentence, fromLanguage, toLanguage).then(
+        }, error => reject(error));
+      }
+    });
+  },
+  translate: function(sentence, fromLanguage, toLanguage) {
+    return new Promise((resolve, reject) => {
+      if (!TranslatorAccessTokenExpired()) {
+        TranslateSentence(memoryStore.get('translatorToken').token, sentence, fromLanguage, toLanguage).then(
                     result => resolve({ translatedSentence: result }), error => reject(error));
-            } else {
-                getAccessTokenForTranslation().then(authBody => {
-                    memoryStore.set('translatorToken', authBody);
-                    TranslateSentence(authBody.token, sentence, fromLanguage, toLanguage).then(
+      } else {
+        getAccessTokenForTranslation().then(authBody => {
+          memoryStore.set('translatorToken', authBody);
+          TranslateSentence(authBody.token, sentence, fromLanguage, toLanguage).then(
                         result => resolve({ translatedSentence: result }), error => reject(error));
-                }, error => reject(error));
-            }
-        });
-    }
+        }, error => reject(error));
+      }
+    });
+  }
 };

--- a/test/BlobStorageManager.js
+++ b/test/BlobStorageManager.js
@@ -4,7 +4,6 @@ const expect = chai.expect;
 const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 
-const TOPIC_SEED_CONTAINER = process.env.TOPIC_SEED_CONTAINER;
 const BLOB_NAME = 'siteTypes/humanitarian/topics/defaultTopics.json';
 const BLOB_NAMES = ['siteTypes/humanitarian/topics/defaultTopics.json', 'siteTypes/health/topics/defaultTopics.json'];
 const SITE_TYPE = 'humanitarian';

--- a/test/BlobStorageManager.js
+++ b/test/BlobStorageManager.js
@@ -1,7 +1,7 @@
 const blobStorageManager = require('../src/storageClients/BlobStorageManager');
-const chai = require('chai');
-const expect = require('chai').expect;
-const chaiAsPromised = require('chai-as-promised');
+const chai = require('chai');
+const expect = chai.expect;
+const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 
 const CONTAINER_NAME = 'settings';

--- a/test/BlobStorageManager.js
+++ b/test/BlobStorageManager.js
@@ -1,70 +1,70 @@
-const blobStorageManager = require("../src/storageClients/BlobStorageManager");
-const chai = require("chai");
+const blobStorageManager = require('../src/storageClients/BlobStorageManager');
+const chai = require('chai');
 const expect = require('chai').expect;
-const chaiAsPromised = require("chai-as-promised");
+const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
-const Promise = require("bluebird");
+const Promise = require('bluebird');
 
-const CONTAINER_NAME = "settings";
-const BLOB_NAME = "siteTypes/humanitarian/topics/defaultTopics.json";
-const BLOB_NAMES = ["siteTypes/humanitarian/topics/defaultTopics.json", "siteTypes/health/topics/defaultTopics.json"];
-const SITE_TYPE = "humanitarian";
+const CONTAINER_NAME = 'settings';
+const BLOB_NAME = 'siteTypes/humanitarian/topics/defaultTopics.json';
+const BLOB_NAMES = ['siteTypes/humanitarian/topics/defaultTopics.json', 'siteTypes/health/topics/defaultTopics.json'];
+const SITE_TYPE = 'humanitarian';
 
 describe('BlobStorageManager', function() {
 
-  describe('#Get(containerName, blobName, id)', function() {
+    describe('#Get(containerName, blobName, id)', function() {
 
-    it('should return a single item', function() {
-      return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, 1)).to.eventually.be.an('object');
-    });
+        it('should return a single item', function() {
+            return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, 1)).to.eventually.be.an('object');
+        });
 
-    it('should return null', function() {
-      return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, -1)).to.eventually.be.a('null');
-    });
+        it('should return null', function() {
+            return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, -1)).to.eventually.be.a('null');
+        });
 
-    it('should throw error on null container', function() {
-      return blobStorageManager.Get(null, BLOB_NAME, 1)
+        it('should throw error on null container', function() {
+            return blobStorageManager.Get(null, BLOB_NAME, 1)
         .then(function(response) {
-          expect(response).to.be.undefined;
+            expect(response).to.be.undefined;
         }).catch(function(err) {
-          expect(err.name).to.equal('ArgumentNullError');
+            expect(err.name).to.equal('ArgumentNullError');
+        });
+        });
+
+        it('should throw error on emptystring container', function() {
+            return blobStorageManager.Get('', BLOB_NAME, 1)
+        .then(function(response) {
+            expect(response).to.be.undefined;
+        }).catch(function(err) {
+            expect(err.name).to.equal('ArgumentNullError');
+        });
+        });
+
+        it('should throw error on null blobName', function() {
+            return blobStorageManager.Get(CONTAINER_NAME, null, 1)
+        .then(function(response) {
+            expect(response).to.be.undefined;
+        }).catch(function(err) {
+            expect(err.name).to.equal('ArgumentNullError');
+        });
+        });
+
+        it('should throw error on emptystring blobName', function() {
+            return blobStorageManager.Get(CONTAINER_NAME, '', 1)
+        .then(function(response) {
+            expect(response).to.be.undefined;
+        }).catch(function(err) {
+            expect(err.name).to.equal('ArgumentNullError');
+        });
+        });
+
+    });
+
+    describe('#List(containerName, blobNames)', function() {
+        it('should return all items for all the blobNames', function() {
+            return expect(blobStorageManager.List(CONTAINER_NAME, BLOB_NAMES)).to.eventually.be.an('object');
         });
     });
-
-    it('should throw error on emptystring container', function() {
-      return blobStorageManager.Get("", BLOB_NAME, 1)
-        .then(function(response) {
-          expect(response).to.be.undefined;
-        }).catch(function(err) {
-          expect(err.name).to.equal('ArgumentNullError');
-        });
-    });
-
-    it('should throw error on null blobName', function() {
-      return blobStorageManager.Get(CONTAINER_NAME, null, 1)
-        .then(function(response) {
-          expect(response).to.be.undefined;
-        }).catch(function(err) {
-          expect(err.name).to.equal('ArgumentNullError');
-        });
-    });
-
-    it('should throw error on emptystring blobName', function() {
-      return blobStorageManager.Get(CONTAINER_NAME, "", 1)
-        .then(function(response) {
-          expect(response).to.be.undefined;
-        }).catch(function(err) {
-          expect(err.name).to.equal('ArgumentNullError');
-        });
-    });
-
-  });
-
-  describe('#List(containerName, blobNames)', function() {
-    it('should return all items for all the blobNames', function() {
-      return expect(blobStorageManager.List(CONTAINER_NAME, BLOB_NAMES)).to.eventually.be.an('object');
-    });
-  });
 
 /*
   describe('#listBlobsInContainer(containerName)', function() {
@@ -73,11 +73,11 @@ describe('BlobStorageManager', function() {
     });
   });
 */
-  describe('#getBlobNamesWithSiteType(containerName, siteType)', function() {
-    it('should return blob names that are of a certain siteType', function() {
-      return expect(blobStorageManager.getBlobNamesWithSiteType(CONTAINER_NAME, SITE_TYPE)).to.eventually.be.an('array');
+    describe('#getBlobNamesWithSiteType(containerName, siteType)', function() {
+        it('should return blob names that are of a certain siteType', function() {
+            return expect(blobStorageManager.getBlobNamesWithSiteType(CONTAINER_NAME, SITE_TYPE)).to.eventually.be.an('array');
+        });
     });
-  });
 
 
 });

--- a/test/BlobStorageManager.js
+++ b/test/BlobStorageManager.js
@@ -4,77 +4,59 @@ const expect = chai.expect;
 const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 
-const CONTAINER_NAME = 'settings';
+const TOPIC_SEED_CONTAINER = process.env.TOPIC_SEED_CONTAINER;
 const BLOB_NAME = 'siteTypes/humanitarian/topics/defaultTopics.json';
 const BLOB_NAMES = ['siteTypes/humanitarian/topics/defaultTopics.json', 'siteTypes/health/topics/defaultTopics.json'];
 const SITE_TYPE = 'humanitarian';
 
 describe('BlobStorageManager', function() {
 
-  describe('#Get(containerName, blobName, id)', function() {
+  describe('#Get(blobName, id)', function() {
 
     it('should return a single item', function() {
-      return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, 1)).to.eventually.be.an('object');
+      return expect(blobStorageManager.Get(BLOB_NAME, 1)).to.eventually.be.an('object');
     });
 
-    it('should return null', function() {
-      return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, -1)).to.eventually.be.a('null');
-    });
-
-    it('should throw error on null container', function() {
-      return blobStorageManager.Get(null, BLOB_NAME, 1)
-        .then(function(response) {
-          expect(response).to.be.undefined;
-        }).catch(function(err) {
-          expect(err.name).to.equal('ArgumentNullError');
-        });
-    });
-
-    it('should throw error on emptystring container', function() {
-      return blobStorageManager.Get('', BLOB_NAME, 1)
-        .then(function(response) {
-          expect(response).to.be.undefined;
-        }).catch(function(err) {
-          expect(err.name).to.equal('ArgumentNullError');
-        });
+    it('should be rejected', function() {
+      return expect(blobStorageManager.Get(BLOB_NAME, -1)).to.eventually.be.rejected;
     });
 
     it('should throw error on null blobName', function() {
-      return blobStorageManager.Get(CONTAINER_NAME, null, 1)
-        .then(function(response) {
+      return blobStorageManager.Get(null, 1)
+        .then(response => {
           expect(response).to.be.undefined;
-        }).catch(function(err) {
+        }).catch(err => {
           expect(err.name).to.equal('ArgumentNullError');
         });
     });
 
     it('should throw error on emptystring blobName', function() {
-      return blobStorageManager.Get(CONTAINER_NAME, '', 1)
-        .then(function(response) {
+      return blobStorageManager.Get('', 1)
+        .then(response => {
           expect(response).to.be.undefined;
-        }).catch(function(err) {
+        }).catch(err => {
           expect(err.name).to.equal('ArgumentNullError');
         });
     });
 
   });
 
-  describe('#List(containerName, blobNames)', function() {
+  describe('#List(blobNames)', function() {
     it('should return all items for all the blobNames', function() {
-      return expect(blobStorageManager.List(CONTAINER_NAME, BLOB_NAMES)).to.eventually.be.an('object');
+      return expect(blobStorageManager.List(BLOB_NAMES)).to.eventually.be.an('object');
     });
   });
 
 /*
-  describe('#listBlobsInContainer(containerName)', function() {
+  describe('#listBlobsInContainer()', function() {
     it('should return all blobs', function() {
-      return expect(blobStorageManager.listBlobsInContainer(CONTAINER_NAME)).to.eventually.be.an('array');
+      return expect(blobStorageManager.listBlobsInContainer()).to.eventually.be.an('array');
     });
   });
 */
-  describe('#getBlobNamesWithSiteType(containerName, siteType)', function() {
+  describe('#getBlobNamesWithSiteType(siteType)', function() {
     it('should return blob names that are of a certain siteType', function() {
-      return expect(blobStorageManager.getBlobNamesWithSiteType(CONTAINER_NAME, SITE_TYPE)).to.eventually.be.an('array');
+      return expect(blobStorageManager.getBlobNamesWithSiteType(SITE_TYPE)).to.eventually.be.an('array');
     });
   });
 

--- a/test/BlobStorageManager.js
+++ b/test/BlobStorageManager.js
@@ -11,59 +11,59 @@ const SITE_TYPE = 'humanitarian';
 
 describe('BlobStorageManager', function() {
 
-    describe('#Get(containerName, blobName, id)', function() {
+  describe('#Get(containerName, blobName, id)', function() {
 
-        it('should return a single item', function() {
-            return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, 1)).to.eventually.be.an('object');
-        });
-
-        it('should return null', function() {
-            return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, -1)).to.eventually.be.a('null');
-        });
-
-        it('should throw error on null container', function() {
-            return blobStorageManager.Get(null, BLOB_NAME, 1)
-        .then(function(response) {
-            expect(response).to.be.undefined;
-        }).catch(function(err) {
-            expect(err.name).to.equal('ArgumentNullError');
-        });
-        });
-
-        it('should throw error on emptystring container', function() {
-            return blobStorageManager.Get('', BLOB_NAME, 1)
-        .then(function(response) {
-            expect(response).to.be.undefined;
-        }).catch(function(err) {
-            expect(err.name).to.equal('ArgumentNullError');
-        });
-        });
-
-        it('should throw error on null blobName', function() {
-            return blobStorageManager.Get(CONTAINER_NAME, null, 1)
-        .then(function(response) {
-            expect(response).to.be.undefined;
-        }).catch(function(err) {
-            expect(err.name).to.equal('ArgumentNullError');
-        });
-        });
-
-        it('should throw error on emptystring blobName', function() {
-            return blobStorageManager.Get(CONTAINER_NAME, '', 1)
-        .then(function(response) {
-            expect(response).to.be.undefined;
-        }).catch(function(err) {
-            expect(err.name).to.equal('ArgumentNullError');
-        });
-        });
-
+    it('should return a single item', function() {
+      return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, 1)).to.eventually.be.an('object');
     });
 
-    describe('#List(containerName, blobNames)', function() {
-        it('should return all items for all the blobNames', function() {
-            return expect(blobStorageManager.List(CONTAINER_NAME, BLOB_NAMES)).to.eventually.be.an('object');
+    it('should return null', function() {
+      return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, -1)).to.eventually.be.a('null');
+    });
+
+    it('should throw error on null container', function() {
+      return blobStorageManager.Get(null, BLOB_NAME, 1)
+        .then(function(response) {
+          expect(response).to.be.undefined;
+        }).catch(function(err) {
+          expect(err.name).to.equal('ArgumentNullError');
         });
     });
+
+    it('should throw error on emptystring container', function() {
+      return blobStorageManager.Get('', BLOB_NAME, 1)
+        .then(function(response) {
+          expect(response).to.be.undefined;
+        }).catch(function(err) {
+          expect(err.name).to.equal('ArgumentNullError');
+        });
+    });
+
+    it('should throw error on null blobName', function() {
+      return blobStorageManager.Get(CONTAINER_NAME, null, 1)
+        .then(function(response) {
+          expect(response).to.be.undefined;
+        }).catch(function(err) {
+          expect(err.name).to.equal('ArgumentNullError');
+        });
+    });
+
+    it('should throw error on emptystring blobName', function() {
+      return blobStorageManager.Get(CONTAINER_NAME, '', 1)
+        .then(function(response) {
+          expect(response).to.be.undefined;
+        }).catch(function(err) {
+          expect(err.name).to.equal('ArgumentNullError');
+        });
+    });
+
+  });
+
+  describe('#List(containerName, blobNames)', function() {
+    it('should return all items for all the blobNames', function() {
+      return expect(blobStorageManager.List(CONTAINER_NAME, BLOB_NAMES)).to.eventually.be.an('object');
+    });
+  });
 
 /*
   describe('#listBlobsInContainer(containerName)', function() {
@@ -72,11 +72,11 @@ describe('BlobStorageManager', function() {
     });
   });
 */
-    describe('#getBlobNamesWithSiteType(containerName, siteType)', function() {
-        it('should return blob names that are of a certain siteType', function() {
-            return expect(blobStorageManager.getBlobNamesWithSiteType(CONTAINER_NAME, SITE_TYPE)).to.eventually.be.an('array');
-        });
+  describe('#getBlobNamesWithSiteType(containerName, siteType)', function() {
+    it('should return blob names that are of a certain siteType', function() {
+      return expect(blobStorageManager.getBlobNamesWithSiteType(CONTAINER_NAME, SITE_TYPE)).to.eventually.be.an('array');
     });
+  });
 
 
 });

--- a/test/BlobStorageManager.js
+++ b/test/BlobStorageManager.js
@@ -1,0 +1,109 @@
+let assert = require('assert');
+let blobStorageManager = require("../src/storageClients/BlobStorageManager");
+let chai = require("chai");
+let expect = require('chai').expect;
+let Promise = require('promise');
+
+const CONTAINER_NAME = "settings";
+
+describe('BlobStorageManager', function() {
+
+  describe('#Get(containerName, blobName, id)', function() {
+
+    /*
+    it('should return a single item', function() {
+      let args = {};
+      args.containerName = "settings";
+      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
+      args.id = 1;
+      args.prefix = "";
+
+      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
+        .then(function(response) {
+          expect(response).to.be.an('object');
+        }).catch(function(err) {
+          expect(Boolean(err)).to.be.false;
+        });
+    });
+    */
+    /*
+    it('should return null', function() {
+      let args = {};
+      args.containerName = "settings";
+      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
+      args.id = -1; //(item does not exist)
+      args.prefix = "";
+
+      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
+        .then(function(response) {
+          expect(Object.keys(response).length).to.equal(0);
+        }).catch(function(err) {
+          console.log(err);
+          expect(Boolean(err)).to.be.false;
+        });
+    });
+
+
+    it('should throw error on null container', function() {
+      let args = {};
+      args.containerName = null;
+      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
+      args.id = 1;
+      args.prefix = "";
+
+      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
+        .then(function(response) {
+          expect(response).to.be.undefined;
+        }).catch(function(err) {
+          expect(err.name).to.equal('ArgumentNullError');
+        });
+    });
+
+    it('should throw error on emptystring container', function() {
+      let args = {};
+      args.containerName = "";
+      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
+      args.id = 1;
+      args.prefix = "";
+
+      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
+        .then(function(response) {
+          expect(response).to.be.undefined;
+        }).catch(function(err) {
+          expect(err.name).to.equal('ArgumentNullError');
+        });
+    });
+
+    it('should throw error on null blobName', function() {
+      let args = {};
+      args.containerName = "settings";
+      args.blobName = null;
+      args.id = 1;
+      args.prefix = "";
+
+      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
+        .then(function(response) {
+          expect(response).to.be.undefined;
+        }).catch(function(err) {
+          expect(err.name).to.equal('ArgumentNullError');
+        });
+    });
+
+    it('should throw error on emptystring blobName', function() {
+      let args = {};
+      args.containerName = "settings";
+      args.blobName = "";
+      args.id = 1;
+      args.prefix = "";
+
+      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
+        .then(function(response) {
+          expect(response).to.be.undefined;
+        }).catch(function(err) {
+          expect(err.name).to.equal('ArgumentNullError');
+        });
+    });
+    */
+
+  });
+});

--- a/test/BlobStorageManager.js
+++ b/test/BlobStorageManager.js
@@ -1,56 +1,29 @@
-let assert = require('assert');
-let blobStorageManager = require("../src/storageClients/BlobStorageManager");
-let chai = require("chai");
-let expect = require('chai').expect;
-let Promise = require('promise');
+const blobStorageManager = require("../src/storageClients/BlobStorageManager");
+const chai = require("chai");
+const expect = require('chai').expect;
+const chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised);
+const Promise = require("bluebird");
 
 const CONTAINER_NAME = "settings";
+const BLOB_NAME = "siteTypes/humanitarian/topics/defaultTopics.json";
+const BLOB_NAMES = ["siteTypes/humanitarian/topics/defaultTopics.json", "siteTypes/health/topics/defaultTopics.json"];
+const SITE_TYPE = "humanitarian";
 
 describe('BlobStorageManager', function() {
 
   describe('#Get(containerName, blobName, id)', function() {
 
     it('should return a single item', function() {
-      let args = {};
-      args.containerName = "settings";
-      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
-      args.id = 1;
-      args.prefix = "";
-
-      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
-        .then(function(response) {
-          expect(response).to.be.an('object');
-        }).catch(function(err) {
-          expect(Boolean(err)).to.be.false;
-        });
+      return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, 1)).to.eventually.be.an('object');
     });
 
-    /*
     it('should return null', function() {
-      let args = {};
-      args.containerName = "settings";
-      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
-      args.id = -1; //(item does not exist)
-      args.prefix = "";
-
-      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
-        .then(function(response) {
-          expect(Object.keys(response).length).to.equal(0);
-        }).catch(function(err) {
-          console.log(err);
-          expect(Boolean(err)).to.be.false;
-        });
+      return expect(blobStorageManager.Get(CONTAINER_NAME, BLOB_NAME, -1)).to.eventually.be.a('null');
     });
-
 
     it('should throw error on null container', function() {
-      let args = {};
-      args.containerName = null;
-      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
-      args.id = 1;
-      args.prefix = "";
-
-      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
+      return blobStorageManager.Get(null, BLOB_NAME, 1)
         .then(function(response) {
           expect(response).to.be.undefined;
         }).catch(function(err) {
@@ -59,13 +32,7 @@ describe('BlobStorageManager', function() {
     });
 
     it('should throw error on emptystring container', function() {
-      let args = {};
-      args.containerName = "";
-      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
-      args.id = 1;
-      args.prefix = "";
-
-      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
+      return blobStorageManager.Get("", BLOB_NAME, 1)
         .then(function(response) {
           expect(response).to.be.undefined;
         }).catch(function(err) {
@@ -74,13 +41,7 @@ describe('BlobStorageManager', function() {
     });
 
     it('should throw error on null blobName', function() {
-      let args = {};
-      args.containerName = "settings";
-      args.blobName = null;
-      args.id = 1;
-      args.prefix = "";
-
-      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
+      return blobStorageManager.Get(CONTAINER_NAME, null, 1)
         .then(function(response) {
           expect(response).to.be.undefined;
         }).catch(function(err) {
@@ -89,35 +50,34 @@ describe('BlobStorageManager', function() {
     });
 
     it('should throw error on emptystring blobName', function() {
-      let args = {};
-      args.containerName = "settings";
-      args.blobName = "";
-      args.id = 1;
-      args.prefix = "";
-
-      return blobStorageManager.Get(args.containerName, args.blobName, args.id)
+      return blobStorageManager.Get(CONTAINER_NAME, "", 1)
         .then(function(response) {
           expect(response).to.be.undefined;
         }).catch(function(err) {
           expect(err.name).to.equal('ArgumentNullError');
         });
     });
-    */
+
   });
 
-  describe('#List(containerName, blobName)', function() {
-    it('should return all items', function() {
-      let args = {};
-      args.containerName = "settings";
-      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
-
-      return blobStorageManager.List(args.containerName, args.blobName)
-        .then(function(response) {
-          expect(response).to.be.an('object');
-        }).catch(function(err) {
-          expect(Boolean(err)).to.be.false;
-        });
+  describe('#List(containerName, blobNames)', function() {
+    it('should return all items for all the blobNames', function() {
+      return expect(blobStorageManager.List(CONTAINER_NAME, BLOB_NAMES)).to.eventually.be.an('object');
     });
   });
+
+/*
+  describe('#listBlobsInContainer(containerName)', function() {
+    it('should return all blobs', function() {
+      return expect(blobStorageManager.listBlobsInContainer(CONTAINER_NAME)).to.eventually.be.an('array');
+    });
+  });
+*/
+  describe('#getBlobNamesWithSiteType(containerName, siteType)', function() {
+    it('should return blob names that are of a certain siteType', function() {
+      return expect(blobStorageManager.getBlobNamesWithSiteType(CONTAINER_NAME, SITE_TYPE)).to.eventually.be.an('array');
+    });
+  });
+
 
 });

--- a/test/BlobStorageManager.js
+++ b/test/BlobStorageManager.js
@@ -3,7 +3,6 @@ const chai = require('chai');
 const expect = require('chai').expect;
 const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
-const Promise = require('bluebird');
 
 const CONTAINER_NAME = 'settings';
 const BLOB_NAME = 'siteTypes/humanitarian/topics/defaultTopics.json';

--- a/test/BlobStorageManager.js
+++ b/test/BlobStorageManager.js
@@ -10,7 +10,6 @@ describe('BlobStorageManager', function() {
 
   describe('#Get(containerName, blobName, id)', function() {
 
-    /*
     it('should return a single item', function() {
       let args = {};
       args.containerName = "settings";
@@ -25,7 +24,7 @@ describe('BlobStorageManager', function() {
           expect(Boolean(err)).to.be.false;
         });
     });
-    */
+
     /*
     it('should return null', function() {
       let args = {};
@@ -104,6 +103,21 @@ describe('BlobStorageManager', function() {
         });
     });
     */
-
   });
+
+  describe('#List(containerName, blobName)', function() {
+    it('should return all items', function() {
+      let args = {};
+      args.containerName = "settings";
+      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
+
+      return blobStorageManager.List(args.containerName, args.blobName)
+        .then(function(response) {
+          expect(response).to.be.an('object');
+        }).catch(function(err) {
+          expect(Boolean(err)).to.be.false;
+        });
+    });
+  });
+
 });

--- a/test/CassandraConnector.js
+++ b/test/CassandraConnector.js
@@ -4,7 +4,6 @@ const chai = require('chai');
 const expect = require('chai').expect;
 const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised); //TODO: see if you can move these test config to a new file see mocha docs
-const Promise = require('bluebird');
 
 const CASSANDRA_CONTACT_POINTS = process.env.CASSANDRA_CONTACT_POINTS;
 

--- a/test/CassandraConnector.js
+++ b/test/CassandraConnector.js
@@ -9,17 +9,17 @@ const CASSANDRA_CONTACT_POINTS = process.env.CASSANDRA_CONTACT_POINTS;
 
 describe('Client', function() {
 
-    describe('#closeClient(client)', function() {
+  describe('#closeClient(client)', function() {
 
-        it('should resolve the promise with the client', function() {
-            const options = {
-                contactPoints: [CASSANDRA_CONTACT_POINTS],
-                keyspace: process.env.CASSANDRA_KEYSPACE
-            };
-            const client = new cassandra.Client(options);
-            return (expect(cassandraConnector.closeClient(client)).to.eventually.be.fulfilled);
-        });
-
+    it('should resolve the promise with the client', function() {
+      const options = {
+        contactPoints: [CASSANDRA_CONTACT_POINTS],
+        keyspace: process.env.CASSANDRA_KEYSPACE
+      };
+      const client = new cassandra.Client(options);
+      return (expect(cassandraConnector.closeClient(client)).to.eventually.be.fulfilled);
     });
+
+  });
 
 });

--- a/test/CassandraConnector.js
+++ b/test/CassandraConnector.js
@@ -1,16 +1,26 @@
-let assert = require('assert');
 const cassandra = require('cassandra-driver');
-let cassandraConnector = require("../src/connectors/CassandraConnector");
+const cassandraConnector = require("../src/connectors/CassandraConnector");
+const chai = require("chai");
+const expect = require('chai').expect;
+const chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised); //TODO: see if you can move these test config to a new file see mocha docs
+const Promise = require("bluebird");
 
-/*
+const CASSANDRA_CONTACT_POINTS = process.env.CASSANDRA_CONTACT_POINTS;
+
 describe('Client', function() {
 
-  describe('#getClient()', function() {
-    it('Get Cassandra client without error', function(done) {
-      cassandraConnector.getClient(['h1, h2'], 'ks1', done)
+  describe('#closeClient(client)', function() {
+
+    it('should resolve the promise with the client', function() {
+      const options = {
+        contactPoints: [CASSANDRA_CONTACT_POINTS],
+        keyspace: process.env.CASSANDRA_KEYSPACE
+      };
+      const client = new cassandra.Client(options);
+      return (expect(cassandraConnector.closeClient(client)).to.eventually.be.fulfilled);
     });
+
   });
 
-
 });
-*/

--- a/test/CassandraConnector.js
+++ b/test/CassandraConnector.js
@@ -1,0 +1,16 @@
+let assert = require('assert');
+const cassandra = require('cassandra-driver');
+let cassandraConnector = require("../src/connectors/CassandraConnector");
+
+/*
+describe('Client', function() {
+
+  describe('#getClient()', function() {
+    it('Get Cassandra client without error', function(done) {
+      cassandraConnector.getClient(['h1, h2'], 'ks1', done)
+    });
+  });
+
+
+});
+*/

--- a/test/CassandraConnector.js
+++ b/test/CassandraConnector.js
@@ -1,26 +1,26 @@
 const cassandra = require('cassandra-driver');
-const cassandraConnector = require("../src/connectors/CassandraConnector");
-const chai = require("chai");
+const cassandraConnector = require('../src/connectors/CassandraConnector');
+const chai = require('chai');
 const expect = require('chai').expect;
-const chaiAsPromised = require("chai-as-promised");
+const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised); //TODO: see if you can move these test config to a new file see mocha docs
-const Promise = require("bluebird");
+const Promise = require('bluebird');
 
 const CASSANDRA_CONTACT_POINTS = process.env.CASSANDRA_CONTACT_POINTS;
 
 describe('Client', function() {
 
-  describe('#closeClient(client)', function() {
+    describe('#closeClient(client)', function() {
 
-    it('should resolve the promise with the client', function() {
-      const options = {
-        contactPoints: [CASSANDRA_CONTACT_POINTS],
-        keyspace: process.env.CASSANDRA_KEYSPACE
-      };
-      const client = new cassandra.Client(options);
-      return (expect(cassandraConnector.closeClient(client)).to.eventually.be.fulfilled);
+        it('should resolve the promise with the client', function() {
+            const options = {
+                contactPoints: [CASSANDRA_CONTACT_POINTS],
+                keyspace: process.env.CASSANDRA_KEYSPACE
+            };
+            const client = new cassandra.Client(options);
+            return (expect(cassandraConnector.closeClient(client)).to.eventually.be.fulfilled);
+        });
+
     });
-
-  });
 
 });

--- a/test/CassandraConnector.js
+++ b/test/CassandraConnector.js
@@ -1,8 +1,8 @@
 const cassandra = require('cassandra-driver');
 const cassandraConnector = require('../src/connectors/CassandraConnector');
-const chai = require('chai');
+const chai = require('chai');
 const expect = require('chai').expect;
-const chaiAsPromised = require('chai-as-promised');
+const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised); //TODO: see if you can move these test config to a new file see mocha docs
 
 const CASSANDRA_CONTACT_POINTS = process.env.CASSANDRA_CONTACT_POINTS;

--- a/test/CassandraTableStorageManager.js
+++ b/test/CassandraTableStorageManager.js
@@ -1,51 +1,51 @@
 const sinon = require('sinon');
 const cassandra = require('cassandra-driver');
-const cassandraTableStorageManager = require("../src/storageClients/CassandraTableStorageManager");
-const chai = require("chai");
+const cassandraTableStorageManager = require('../src/storageClients/CassandraTableStorageManager');
+const chai = require('chai');
 const expect = require('chai').expect;
-const Promise = require("bluebird");
+const Promise = require('bluebird');
 
 const queries = [
-  {
-    query: 'INSERT INTO Topics (id, topic, value) VALUES (?, ?, ?)',
-    params: [ 1, "toxin", "en" ]
-  },
-  {
-    query: 'INSERT INTO Topics (id, topic, value) VALUES (?, ?, ?)',
-    params: [ 2, "pollution", "en" ]
-  }
+    {
+        query: 'INSERT INTO Topics (id, topic, value) VALUES (?, ?, ?)',
+        params: [ 1, 'toxin', 'en' ]
+    },
+    {
+        query: 'INSERT INTO Topics (id, topic, value) VALUES (?, ?, ?)',
+        params: [ 2, 'pollution', 'en' ]
+    }
 ];
 
 const CASSANDRA_CONTACT_POINTS = process.env.CASSANDRA_CONTACT_POINTS;
 
 describe('CassandraTableStorageManager', function() {
 
-  describe('#batch(queries)', function() {
-    const options = {
-      contactPoints: [CASSANDRA_CONTACT_POINTS],
-      keyspace: process.env.CASSANDRA_KEYSPACE
-    };
-    const client = new cassandra.Client(options);
+    describe('#batch(queries)', function() {
+        const options = {
+            contactPoints: [CASSANDRA_CONTACT_POINTS],
+            keyspace: process.env.CASSANDRA_KEYSPACE
+        };
+        const client = new cassandra.Client(options);
 
-    it('Cassandra client should insert items in batches without error', function() {
-      return expect(cassandraTableStorageManager.batch(client, queries)).to.eventually.be.fulfilled;
+        it('Cassandra client should insert items in batches without error', function() {
+            return expect(cassandraTableStorageManager.batch(client, queries)).to.eventually.be.fulfilled;
+        });
+
     });
 
-  });
+    describe('#prepareInsertTopic(topic)', function() {
 
-  describe('#prepareInsertTopic(topic)', function() {
+        it('Prepares the query object without error', function() {
 
-    it('Prepares the query object without error', function() {
+            let topic = {
+                id: 1,
+                topic: 'health',
+                value: 'en'
+            };
 
-      let topic = {
-        id: 1,
-        topic: "health",
-        value: "en"
-      }
+            return expect(cassandraTableStorageManager.prepareInsertTopic(topic)).to.have.property('query');
+        });
 
-      return expect(cassandraTableStorageManager.prepareInsertTopic(topic)).to.have.property('query')
     });
-
-  });
 
 });

--- a/test/CassandraTableStorageManager.js
+++ b/test/CassandraTableStorageManager.js
@@ -1,0 +1,26 @@
+let assert = require('assert');
+let sinon = require('sinon');
+const cassandra = require('cassandra-driver');
+let cassandraTableStorageManager = require("../src/storageClients/CassandraTableStorageManager");
+let cassandraConnector = require("../src/connectors/CassandraConnector");
+
+/*
+describe('CassandraTableStorageManager', function() {
+
+  describe('#insert(siteType, items)', function() {
+
+    it('Cassandra client should insert items without error', function(done) {
+      cassandraTableStorageManager.insert('humanitarian', [{RowKey: 1, name: 'topic1', value: 'topic2'}], done)
+    });
+  });
+
+});
+*/
+
+/*    it('should call getClient once', function() {
+      var client = sinon.spy(cassandraConnector, 'getClient');
+
+      cassandraTableStorageManager.insert('humanitarian', [{RowKey: 1, name: 'topic1', value: 'topic2'}])
+
+      sinon.assert.calledOnce(client);
+    });*/

--- a/test/CassandraTableStorageManager.js
+++ b/test/CassandraTableStorageManager.js
@@ -1,6 +1,6 @@
 const cassandra = require('cassandra-driver');
 const cassandraTableStorageManager = require('../src/storageClients/CassandraTableStorageManager');
-const chai = require('chai');
+const chai = require('chai');
 const expect = chai.expect;
 
 const queries = [
@@ -26,7 +26,7 @@ describe('CassandraTableStorageManager', function() {
     const client = new cassandra.Client(options);
 
     it('Cassandra client should insert items in batches without error', function() {
-      return expect(cassandraTableStorageManager.batch(client, queries)).to.eventually.be.fulfilled;
+      return expect(cassandraTableStorageManager.batch(client, queries)).to.eventually.be.fulfilled;
     });
 
   });

--- a/test/CassandraTableStorageManager.js
+++ b/test/CassandraTableStorageManager.js
@@ -4,46 +4,46 @@ const chai = require('chai');
 const expect = chai.expect;
 
 const queries = [
-    {
-        query: 'INSERT INTO Topics (id, topic, value) VALUES (?, ?, ?)',
-        params: [ 1, 'toxin', 'en' ]
-    },
-    {
-        query: 'INSERT INTO Topics (id, topic, value) VALUES (?, ?, ?)',
-        params: [ 2, 'pollution', 'en' ]
-    }
+  {
+    query: 'INSERT INTO Topics (id, topic, value) VALUES (?, ?, ?)',
+    params: [ 1, 'toxin', 'en' ]
+  },
+  {
+    query: 'INSERT INTO Topics (id, topic, value) VALUES (?, ?, ?)',
+    params: [ 2, 'pollution', 'en' ]
+  }
 ];
 
 const CASSANDRA_CONTACT_POINTS = process.env.CASSANDRA_CONTACT_POINTS;
 
 describe('CassandraTableStorageManager', function() {
 
-    describe('#batch(queries)', function() {
-        const options = {
-            contactPoints: [CASSANDRA_CONTACT_POINTS],
-            keyspace: process.env.CASSANDRA_KEYSPACE
-        };
-        const client = new cassandra.Client(options);
+  describe('#batch(queries)', function() {
+    const options = {
+      contactPoints: [CASSANDRA_CONTACT_POINTS],
+      keyspace: process.env.CASSANDRA_KEYSPACE
+    };
+    const client = new cassandra.Client(options);
 
-        it('Cassandra client should insert items in batches without error', function() {
-            return expect(cassandraTableStorageManager.batch(client, queries)).to.eventually.be.fulfilled;
-        });
-
+    it('Cassandra client should insert items in batches without error', function() {
+      return expect(cassandraTableStorageManager.batch(client, queries)).to.eventually.be.fulfilled;
     });
 
-    describe('#prepareInsertTopic(topic)', function() {
+  });
 
-        it('Prepares the query object without error', function() {
+  describe('#prepareInsertTopic(topic)', function() {
 
-            let topic = {
-                id: 1,
-                topic: 'health',
-                value: 'en'
-            };
+    it('Prepares the query object without error', function() {
 
-            return expect(cassandraTableStorageManager.prepareInsertTopic(topic)).to.have.property('query');
-        });
+      let topic = {
+        id: 1,
+        topic: 'health',
+        value: 'en'
+      };
 
+      return expect(cassandraTableStorageManager.prepareInsertTopic(topic)).to.have.property('query');
     });
+
+  });
 
 });

--- a/test/CassandraTableStorageManager.js
+++ b/test/CassandraTableStorageManager.js
@@ -1,9 +1,7 @@
-const sinon = require('sinon');
 const cassandra = require('cassandra-driver');
 const cassandraTableStorageManager = require('../src/storageClients/CassandraTableStorageManager');
 const chai = require('chai');
-const expect = require('chai').expect;
-const Promise = require('bluebird');
+const expect = chai.expect;
 
 const queries = [
     {

--- a/test/CassandraTableStorageManager.js
+++ b/test/CassandraTableStorageManager.js
@@ -1,26 +1,51 @@
-let assert = require('assert');
-let sinon = require('sinon');
+const sinon = require('sinon');
 const cassandra = require('cassandra-driver');
-let cassandraTableStorageManager = require("../src/storageClients/CassandraTableStorageManager");
-let cassandraConnector = require("../src/connectors/CassandraConnector");
+const cassandraTableStorageManager = require("../src/storageClients/CassandraTableStorageManager");
+const chai = require("chai");
+const expect = require('chai').expect;
+const Promise = require("bluebird");
 
-/*
+const queries = [
+  {
+    query: 'INSERT INTO Topics (id, topic, value) VALUES (?, ?, ?)',
+    params: [ 1, "toxin", "en" ]
+  },
+  {
+    query: 'INSERT INTO Topics (id, topic, value) VALUES (?, ?, ?)',
+    params: [ 2, "pollution", "en" ]
+  }
+];
+
+const CASSANDRA_CONTACT_POINTS = process.env.CASSANDRA_CONTACT_POINTS;
+
 describe('CassandraTableStorageManager', function() {
 
-  describe('#insert(siteType, items)', function() {
+  describe('#batch(queries)', function() {
+    const options = {
+      contactPoints: [CASSANDRA_CONTACT_POINTS],
+      keyspace: process.env.CASSANDRA_KEYSPACE
+    };
+    const client = new cassandra.Client(options);
 
-    it('Cassandra client should insert items without error', function(done) {
-      cassandraTableStorageManager.insert('humanitarian', [{RowKey: 1, name: 'topic1', value: 'topic2'}], done)
+    it('Cassandra client should insert items in batches without error', function() {
+      return expect(cassandraTableStorageManager.batch(client, queries)).to.eventually.be.fulfilled;
     });
+
+  });
+
+  describe('#prepareInsertTopic(topic)', function() {
+
+    it('Prepares the query object without error', function() {
+
+      let topic = {
+        id: 1,
+        topic: "health",
+        value: "en"
+      }
+
+      return expect(cassandraTableStorageManager.prepareInsertTopic(topic)).to.have.property('query')
+    });
+
   });
 
 });
-*/
-
-/*    it('should call getClient once', function() {
-      var client = sinon.spy(cassandraConnector, 'getClient');
-
-      cassandraTableStorageManager.insert('humanitarian', [{RowKey: 1, name: 'topic1', value: 'topic2'}])
-
-      sinon.assert.calledOnce(client);
-    });*/

--- a/test/Settings.js
+++ b/test/Settings.js
@@ -1,0 +1,50 @@
+const settings = require("../src/resolvers/Settings");
+const chai = require("chai");
+const expect = require('chai').expect;
+const Promise = require("bluebird");
+const cassandra = require('cassandra-driver');
+
+const CONTAINER_NAME = "settings";
+const SITE_TYPE = 'humanitarian';
+
+describe('Settings', function() {
+  //only use below test if you commentted out insertorreplacesitedef
+  /*
+  describe('#createOrReplaceSite(args,res)', function() {
+    it('should return a resolved result', function() {
+      let args = {};
+      args.input = {
+        targetBbox: [],
+        defaultZoomLevel: 1,
+        logo: "",
+        title: "",
+        name: "",
+        defaultLocation:[],
+        storageConnectionString: "",
+        featuresConnectionString: "",
+        mapzenApiKey: "",
+        fbToken: "",
+        supportedLanguages: ["en"],
+        siteType: 'humanitarian'
+      };
+      let res = "";
+
+      return settings.createOrReplaceSite(args, res);
+    });
+  })
+  */
+
+  /*
+  describe('#insertSeedTopics(client, siteType)', function() {
+    it('should insert topics into cassandra', function() {
+      const options = {
+        contactPoints: [process.env.CASSANDRA_CONTACT_POINTS],
+        keyspace: process.env.CASSANDRA_KEYSPACE
+      };
+      const client = new cassandra.Client(options);
+      return expect(settings.insertSeedTopics(client, SITE_TYPE)).to.eventually.be.fulfilled;
+    });
+  });
+  */
+
+});

--- a/test/Settings.js
+++ b/test/Settings.js
@@ -1,10 +1,10 @@
-const settings = require("../src/resolvers/Settings");
-const chai = require("chai");
+const settings = require('../src/resolvers/Settings');
+const chai = require('chai');
 const expect = require('chai').expect;
-const Promise = require("bluebird");
+const Promise = require('bluebird');
 const cassandra = require('cassandra-driver');
 
-const CONTAINER_NAME = "settings";
+const CONTAINER_NAME = 'settings';
 const SITE_TYPE = 'humanitarian';
 
 describe('Settings', function() {

--- a/test/Settings.js
+++ b/test/Settings.js
@@ -1,5 +1,5 @@
 /*const settings = require('../src/resolvers/Settings');
-const chai = require('chai');
+const chai = require('chai');
 const expect = require('chai').expect;
 const Promise = require('bluebird');
 const cassandra = require('cassandra-driver');

--- a/test/Settings.js
+++ b/test/Settings.js
@@ -1,4 +1,4 @@
-const settings = require('../src/resolvers/Settings');
+/*const settings = require('../src/resolvers/Settings');
 const chai = require('chai');
 const expect = require('chai').expect;
 const Promise = require('bluebird');
@@ -8,6 +8,7 @@ const CONTAINER_NAME = 'settings';
 const SITE_TYPE = 'humanitarian';
 
 describe('Settings', function() {
+*/
   //only use below test if you commentted out insertorreplacesitedef
   /*
   describe('#createOrReplaceSite(args,res)', function() {
@@ -47,4 +48,4 @@ describe('Settings', function() {
   });
   */
 
-});
+//});

--- a/test/Settings.js
+++ b/test/Settings.js
@@ -10,7 +10,7 @@ const SITE_TYPE = 'humanitarian';
 describe('Settings', function() {
 */
   //only use below test if you commentted out insertorreplacesitedef
-  /*
+/*
   describe('#createOrReplaceSite(args,res)', function() {
     it('should return a resolved result', function() {
       let args = {};
@@ -33,7 +33,7 @@ describe('Settings', function() {
       return settings.createOrReplaceSite(args, res);
     });
   })
-  */
+*/
 
   /*
   describe('#insertSeedTopics(client, siteType)', function() {

--- a/test/Topics.js
+++ b/test/Topics.js
@@ -8,39 +8,39 @@ const BLOB_NAMES = ['siteTypes/humanitarian/topics/defaultTopics.json', 'siteTyp
 
 describe('Topics', function() {
 
-    describe('#get(args)', function() {
+  describe('#get(args)', function() {
 
-        it('should return a single item', function() {
-            let args = {};
-            args.containerName = CONTAINER_NAME;
-            args.blobName = BLOB_NAME;
-            args.id = 1;
+    it('should return a single item', function() {
+      let args = {};
+      args.containerName = CONTAINER_NAME;
+      args.blobName = BLOB_NAME;
+      args.id = 1;
 
-            return topics.get(args)
+      return topics.get(args)
         .then(function(response) {
-            expect(response).to.be.an('object');
+          expect(response).to.be.an('object');
         }).catch(function(err) {
-            expect(Boolean(err)).to.be.false;
+          expect(Boolean(err)).to.be.false;
         });
-        });
-
     });
 
-    describe('#list(args)', function() {
+  });
 
-        it('should return an object with key collection', function() {
-            let args = {};
-            args.containerName = CONTAINER_NAME;
-            args.blobName = BLOB_NAMES;
+  describe('#list(args)', function() {
 
-            return topics.list(args)
+    it('should return an object with key collection', function() {
+      let args = {};
+      args.containerName = CONTAINER_NAME;
+      args.blobName = BLOB_NAMES;
+
+      return topics.list(args)
         .then(function(response) {
-            expect(response).to.be.an('object').that.has.all.keys('collection');
+          expect(response).to.be.an('object').that.has.all.keys('collection');
         }).catch(function(err) {
-            expect(Boolean(err)).to.be.false;
+          expect(Boolean(err)).to.be.false;
         });
-        });
-
     });
+
+  });
 
 });

--- a/test/Topics.js
+++ b/test/Topics.js
@@ -1,7 +1,6 @@
 const topics = require('../src/resolvers/Topics');
 const chai = require('chai');
-const expect = require('chai').expect;
-const Promise = require('bluebird');
+const expect = chai.expect;
 
 const CONTAINER_NAME = 'settings';
 const BLOB_NAME = 'siteTypes/humanitarian/topics/defaultTopics.json';
@@ -16,7 +15,6 @@ describe('Topics', function() {
             args.containerName = CONTAINER_NAME;
             args.blobName = BLOB_NAME;
             args.id = 1;
-            args.prefix = '';
 
             return topics.get(args)
         .then(function(response) {

--- a/test/Topics.js
+++ b/test/Topics.js
@@ -20,16 +20,29 @@ describe('Topics', function() {
 
       return topics.get(args)
         .then(function(response) {
-          console.log("response", response);
           expect(response).to.be.an('object');
         }).catch(function(err) {
-          console.log("WUTTT", err);
           expect(Boolean(err)).to.be.false;
         });
     });
 
   });
 
+  describe('#list(args)', function() {
 
+    it('should return an array', function() {
+      let args = {};
+      args.containerName = "settings";
+      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
+
+      return topics.list(args)
+        .then(function(response) {
+          expect(response).to.be.an('object');
+        }).catch(function(err) {
+          expect(Boolean(err)).to.be.false;
+        });
+    });
+
+  });
 
 });

--- a/test/Topics.js
+++ b/test/Topics.js
@@ -2,7 +2,6 @@ const topics = require('../src/resolvers/Topics');
 const chai = require('chai');
 const expect = chai.expect;
 
-const CONTAINER_NAME = 'settings';
 const BLOB_NAME = 'siteTypes/humanitarian/topics/defaultTopics.json';
 const BLOB_NAMES = ['siteTypes/humanitarian/topics/defaultTopics.json', 'siteTypes/health/topics/defaultTopics.json'];
 
@@ -12,14 +11,13 @@ describe('Topics', function() {
 
     it('should return a single item', function() {
       let args = {};
-      args.containerName = CONTAINER_NAME;
       args.blobName = BLOB_NAME;
       args.id = 1;
 
       return topics.get(args)
-        .then(function(response) {
+        .then(response => {
           expect(response).to.be.an('object');
-        }).catch(function(err) {
+        }).catch(err => {
           expect(Boolean(err)).to.be.false;
         });
     });
@@ -30,13 +28,12 @@ describe('Topics', function() {
 
     it('should return an object with key collection', function() {
       let args = {};
-      args.containerName = CONTAINER_NAME;
       args.blobName = BLOB_NAMES;
 
       return topics.list(args)
-        .then(function(response) {
+        .then(response => {
           expect(response).to.be.an('object').that.has.all.keys('collection');
-        }).catch(function(err) {
+        }).catch(err => {
           expect(Boolean(err)).to.be.false;
         });
     });

--- a/test/Topics.js
+++ b/test/Topics.js
@@ -1,48 +1,48 @@
-const topics = require("../src/resolvers/Topics");
-const chai = require("chai");
+const topics = require('../src/resolvers/Topics');
+const chai = require('chai');
 const expect = require('chai').expect;
-const Promise = require("bluebird");
+const Promise = require('bluebird');
 
-const CONTAINER_NAME = "settings";
-const BLOB_NAME = "siteTypes/humanitarian/topics/defaultTopics.json";
-const BLOB_NAMES = ["siteTypes/humanitarian/topics/defaultTopics.json", "siteTypes/health/topics/defaultTopics.json"]
+const CONTAINER_NAME = 'settings';
+const BLOB_NAME = 'siteTypes/humanitarian/topics/defaultTopics.json';
+const BLOB_NAMES = ['siteTypes/humanitarian/topics/defaultTopics.json', 'siteTypes/health/topics/defaultTopics.json'];
 
 describe('Topics', function() {
 
-  describe('#get(args)', function() {
+    describe('#get(args)', function() {
 
-    it('should return a single item', function() {
-      let args = {};
-      args.containerName = CONTAINER_NAME;
-      args.blobName = BLOB_NAME;
-      args.id = 1;
-      args.prefix = "";
+        it('should return a single item', function() {
+            let args = {};
+            args.containerName = CONTAINER_NAME;
+            args.blobName = BLOB_NAME;
+            args.id = 1;
+            args.prefix = '';
 
-      return topics.get(args)
+            return topics.get(args)
         .then(function(response) {
-          expect(response).to.be.an('object');
+            expect(response).to.be.an('object');
         }).catch(function(err) {
-          expect(Boolean(err)).to.be.false;
+            expect(Boolean(err)).to.be.false;
         });
+        });
+
     });
 
-  });
+    describe('#list(args)', function() {
 
-  describe('#list(args)', function() {
+        it('should return an object with key collection', function() {
+            let args = {};
+            args.containerName = CONTAINER_NAME;
+            args.blobName = BLOB_NAMES;
 
-    it('should return an object with key collection', function() {
-      let args = {};
-      args.containerName = CONTAINER_NAME;
-      args.blobName = BLOB_NAMES;
-
-      return topics.list(args)
+            return topics.list(args)
         .then(function(response) {
-          expect(response).to.be.an('object').that.has.all.keys('collection');
+            expect(response).to.be.an('object').that.has.all.keys('collection');
         }).catch(function(err) {
-          expect(Boolean(err)).to.be.false;
+            expect(Boolean(err)).to.be.false;
         });
-    });
+        });
 
-  });
+    });
 
 });

--- a/test/Topics.js
+++ b/test/Topics.js
@@ -1,11 +1,11 @@
-let topics = require("../src/resolvers/Topics");
-var chai = require("chai");
-chai.should();
-let expect = require('chai').expect;
-let Promise = require('promise');
+const topics = require("../src/resolvers/Topics");
+const chai = require("chai");
+const expect = require('chai').expect;
+const Promise = require("bluebird");
 
 const CONTAINER_NAME = "settings";
-
+const BLOB_NAME = "siteTypes/humanitarian/topics/defaultTopics.json";
+const BLOB_NAMES = ["siteTypes/humanitarian/topics/defaultTopics.json", "siteTypes/health/topics/defaultTopics.json"]
 
 describe('Topics', function() {
 
@@ -13,8 +13,8 @@ describe('Topics', function() {
 
     it('should return a single item', function() {
       let args = {};
-      args.containerName = "settings";
-      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
+      args.containerName = CONTAINER_NAME;
+      args.blobName = BLOB_NAME;
       args.id = 1;
       args.prefix = "";
 
@@ -30,14 +30,14 @@ describe('Topics', function() {
 
   describe('#list(args)', function() {
 
-    it('should return an array', function() {
+    it('should return an object with key collection', function() {
       let args = {};
-      args.containerName = "settings";
-      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
+      args.containerName = CONTAINER_NAME;
+      args.blobName = BLOB_NAMES;
 
       return topics.list(args)
         .then(function(response) {
-          expect(response).to.be.an('object');
+          expect(response).to.be.an('object').that.has.all.keys('collection');
         }).catch(function(err) {
           expect(Boolean(err)).to.be.false;
         });

--- a/test/Topics.js
+++ b/test/Topics.js
@@ -1,0 +1,35 @@
+let topics = require("../src/resolvers/Topics");
+var chai = require("chai");
+chai.should();
+let expect = require('chai').expect;
+let Promise = require('promise');
+
+const CONTAINER_NAME = "settings";
+
+
+describe('Topics', function() {
+
+  describe('#get(args)', function() {
+
+    it('should return a single item', function() {
+      let args = {};
+      args.containerName = "settings";
+      args.blobName = "siteTypes/humanitarian/topics/defaultTopics.json";
+      args.id = 1;
+      args.prefix = "";
+
+      return topics.get(args)
+        .then(function(response) {
+          console.log("response", response);
+          expect(response).to.be.an('object');
+        }).catch(function(err) {
+          console.log("WUTTT", err);
+          expect(Boolean(err)).to.be.false;
+        });
+    });
+
+  });
+
+
+
+});

--- a/test/Topics.js
+++ b/test/Topics.js
@@ -1,5 +1,5 @@
 const topics = require('../src/resolvers/Topics');
-const chai = require('chai');
+const chai = require('chai');
 const expect = chai.expect;
 
 const CONTAINER_NAME = 'settings';


### PR DESCRIPTION
This pull requests allows [crisis lex topics](https://github.com/sajao/CrisisLex/tree/master/data) to be pulled based on siteType from azure blob storage into Cassandra using [datastax nodejs-driver](https://github.com/datastax/nodejs-driver).

See **/resolvers/Settings.js: createOrReplaceSite** for most of my changes.

I created a temporary TopicsSchema so that I could make graphql /get and /list queries for topics. If there is a change to the TopicsSchema, we will need to update **CassandraTableStorageManager.prepareInsertTopic** to account for the schema change.

One more major change was the addition of:
const Promise = require('bluebird');
const azure = Promise.promisifyAll(require('azure-storage'));
I felt that changing it from cb style to promise style made the code a little easier to read.

Another minor addition was mocha unit tests. They definitely can be improved with mocks, stubs, etc.

Another note: I was able to insert topics into my local Cassandra cluster.

I added some environment variables to my FortisEnv.sh, so you might want to as well:
**BLOB_STORAGE_CONNECTION_STRING
CASSANDRA_KEYSPACE
CASSANDRA_CONTACT_POINTS**

**Pending:** 
- add appinsights
- use sinon in unit tests
- finalizing options for Cassandra client

**Questions**
- createOrReplaceSite takes two arguments (args, res). What is *res*?
