### PR TITLE
Add skeletons for new Cassandra resolvers

### DIFF
--- a/src/resolvers-cassandra/Edges.js
+++ b/src/resolvers-cassandra/Edges.js
@@ -1,0 +1,34 @@
+'use strict';
+
+module.exports = {
+    // ---------------------------------------------------------------------------------- mutations
+
+    removeKeywords(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    addKeywords(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    saveLocations(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    removeLocations(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    // ------------------------------------------------------------------------------------ queries
+
+    terms(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    locations(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    popularLocations(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    timeSeries(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    topSources(args,res) { // eslint-disable-line no-unused-vars
+    }
+};

--- a/src/resolvers-cassandra/Facts.js
+++ b/src/resolvers-cassandra/Facts.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+    // ------------------------------------------------------------------------------------ queries
+
+    list(args, res) { // eslint-disable-line no-unused-vars
+    },
+
+    get(args, res) { // eslint-disable-line no-unused-vars
+    }
+};

--- a/src/resolvers-cassandra/Messages.js
+++ b/src/resolvers-cassandra/Messages.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+    // ---------------------------------------------------------------------------------- mutations
+
+    publishEvents(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    // ------------------------------------------------------------------------------------ queries
+
+    byBbox(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    byEdges(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    event(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    translate(args, res) { // eslint-disable-line no-unused-vars
+    },
+
+    translateWords(args, res) { // eslint-disable-line no-unused-vars
+    }
+};

--- a/src/resolvers-cassandra/Settings.js
+++ b/src/resolvers-cassandra/Settings.js
@@ -1,0 +1,52 @@
+'use strict';
+
+module.exports = {
+    // ---------------------------------------------------------------------------------- mutations
+
+    createOrReplaceSite(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    modifyFacebookPages(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    removeFacebookPages(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    modifyTrustedTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    removeTrustedTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    modifyTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    removeTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    modifyBlacklist(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    removeBlacklist(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    // ------------------------------------------------------------------------------------ queries
+
+    sites(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    twitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    trustedTwitterAccounts(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    facebookPages(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    facebookAnalytics(args, res) { // eslint-disable-line no-unused-vars
+    },
+
+    termBlacklist(args, res){ // eslint-disable-line no-unused-vars
+    }
+};

--- a/src/resolvers-cassandra/Tiles.js
+++ b/src/resolvers-cassandra/Tiles.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+    // ------------------------------------------------------------------------------------ queries
+
+    fetchTilesByBBox(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    fetchTilesByLocations(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    fetchPlacesByBBox(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    fetchEdgesByLocations(args, res){ // eslint-disable-line no-unused-vars
+    },
+
+    fetchEdgesByBBox(args, res){ // eslint-disable-line no-unused-vars
+    }
+};


### PR DESCRIPTION
Adding skeletons for all the endpoints listed in [project-fortis-spark#17](https://github.com/CatalystCode/project-fortis-spark/issues/17). We need to implement each of these endpoints in terms of the new Cassandra schema.