### PR TITLE
Implement {save,remove}Locations resolver

### DIFF
--- a/src/resolvers-cassandra/Edges.js
+++ b/src/resolvers-cassandra/Edges.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-    // ---------------------------------------------------------------------------------- mutations
+  // ---------------------------------------------------------------------------------- mutations
 
   removeKeywords(args, res){ // eslint-disable-line no-unused-vars
   },
@@ -10,12 +10,22 @@ module.exports = {
   },
 
   saveLocations(args, res){ // eslint-disable-line no-unused-vars
+    // this is now handled by spark:
+    // we get the coordinates of the geofence
+    // that is configured in the sitesettings table
+    // and use those to filter the twitter stream
+    return null;
   },
 
   removeLocations(args, res){ // eslint-disable-line no-unused-vars
+    // this is now handled by spark:
+    // we get the coordinates of the geofence
+    // that is configured in the sitesettings table
+    // and use those to filter the twitter stream
+    return null;
   },
 
-    // ------------------------------------------------------------------------------------ queries
+  // ------------------------------------------------------------------------------------ queries
 
   terms(args, res){ // eslint-disable-line no-unused-vars
   },

--- a/src/resolvers-cassandra/Edges.js
+++ b/src/resolvers-cassandra/Edges.js
@@ -10,19 +10,23 @@ module.exports = {
   },
 
   saveLocations(args, res){ // eslint-disable-line no-unused-vars
-    // this is now handled by spark:
-    // we get the coordinates of the geofence
-    // that is configured in the sitesettings table
-    // and use those to filter the twitter stream
-    return null;
+    return new Promise((resolve, reject) => { // eslint-disable-line no-unused-vars
+      reject(
+        'This API call is no longer supported. ' +
+        'We now automatically filter events down to only those ' +
+        'locations defined in the geo-fence for your site'
+      );
+    });
   },
 
   removeLocations(args, res){ // eslint-disable-line no-unused-vars
-    // this is now handled by spark:
-    // we get the coordinates of the geofence
-    // that is configured in the sitesettings table
-    // and use those to filter the twitter stream
-    return null;
+    return new Promise((resolve, reject) => { // eslint-disable-line no-unused-vars
+      reject(
+        'This API call is no longer supported. ' +
+        'We now automatically filter events down to only those ' +
+        'locations defined in the geo-fence for your site'
+      );
+    });
   },
 
   // ------------------------------------------------------------------------------------ queries


### PR DESCRIPTION
As mentioned in [project-fortis-spark#17](https://github.com/CatalystCode/project-fortis-spark/issues/17), we no longer need these endpoints as the functionality is now handled directly by Spark.