### PR TITLE
Detect bad imports in eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,13 @@
         "es6": true,
         "node": true
     },
-    "extends": "eslint:recommended",
+    "extends": [
+        "plugin:require-path-exists/recommended",
+        "eslint:recommended"
+    ],
+    "plugins": [
+        "require-path-exists"
+    ],
      "globals": {
         "it": false,
         "describe": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,6 +253,12 @@
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
       "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
     },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
     "bytes": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
@@ -624,6 +630,12 @@
         }
       }
     },
+    "eslint-plugin-require-path-exists": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-require-path-exists/-/eslint-plugin-require-path-exists-1.1.7.tgz",
+      "integrity": "sha1-P4quoWAYmOwREJfwyE84AmxOJ3c=",
+      "dev": true
+    },
     "espree": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
@@ -770,6 +782,20 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
       "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+    },
+    "fs-plus": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.0.1.tgz",
+      "integrity": "sha1-VMFpxA4ohKZtNSeA0Y3TH5HToQ0=",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2077,6 +2103,20 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
+    "underscore-plus": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
+      "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "dev": true,
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,9 @@
   },
   "devDependencies": {
     "eslint": "^2",
-    "istanbul": "~0.4.3",
+    "eslint-plugin-require-path-exists": "^1.1.7",
     "is-my-json-valid": "^2.13.1",
+    "istanbul": "~0.4.3",
     "js-yaml": "^3.2.6",
     "supertest": "^1.2.0",
     "tape": "^4"


### PR DESCRIPTION
After merging this pull request, the eslint step in our CI pipeline will fail if there is any `require` call against a dependency that doesn't exist.

For example, this will protect us against the following types of problems:

```js
const Promise = require('promse');
const eventHubSender = require('../eventhubClient/EventHubSemder');
```

Sample build that detected a bad import: [Job#94.1](https://travis-ci.org/CatalystCode/project-fortis-services/jobs/248471945).