### PR TITLE
Consistency fixes

### DIFF
--- a/src/clients/eventhub/EventHubSender.js
+++ b/src/clients/eventhub/EventHubSender.js
@@ -11,16 +11,14 @@ const eventHubClient = EventHubClient.fromConnectionString(eventHubConnectionStr
 function sendMessages(messages) {
   return new Promise((resolve, reject) => {
     if (!messages || !messages.length) {
-      reject('No messages to be sent');
-      return;
+      return reject('No messages to be sent');
     }
 
     let payloads;
     try {
       payloads = messages.map(message => ({contents: JSON.stringify(message)}));
     } catch (err) {
-      reject(`Unable to create payloads for EventHub: ${err}`);
-      return;
+      return reject(`Unable to create payloads for EventHub: ${err}`);
     }
 
     eventHubClient.open()

--- a/src/clients/facebook/FacebookAnalyticsClient.js
+++ b/src/clients/facebook/FacebookAnalyticsClient.js
@@ -16,22 +16,19 @@ function fetchPageLastUpdatedAt(pageId) {
   return new Promise((resolve, reject) => {
     request.get(buildFeedUri(pageId), (err, response, body) => {
       if (err || response.statusCode !== 200) {
-        reject(`Unable to call Facebook API: ${err}`);
-        return;
+        return reject(`Unable to call Facebook API: ${err}`);
       }
 
       let feed;
       try {
         feed = JSON.parse(body);
       } catch (err) {
-        reject(`Unable to parse JSON for feed response ${body}: ${err}`);
-        return;
+        return reject(`Unable to parse JSON for feed response ${body}: ${err}`);
       }
 
       const lastPostTime = feed && feed.data && feed.data.length && feed.data[0] && feed.data[0].created_time;
       if (!lastPostTime) {
-        reject(`Unable to look up last post time in feed response: ${body}`);
-        return;
+        return reject(`Unable to look up last post time in feed response: ${body}`);
       }
 
       resolve(lastPostTime);

--- a/src/clients/locations/FeatureServiceClient.js
+++ b/src/clients/locations/FeatureServiceClient.js
@@ -25,22 +25,19 @@ function callFeatureService(uri) {
   return new Promise((resolve, reject) => {
     request.get(uri, (err, response, body) => {
       if (err || response.statusCode !== 200) {
-        reject(`Unable to call feature service: ${err}`);
-        return;
+        return reject(`Unable to call feature service: ${err}`);
       }
 
       let featuresCollection;
       try {
         featuresCollection = JSON.parse(body);
       } catch (err) {
-        reject(`Unable to parse JSON for feature service response ${body}: ${err}`);
-        return;
+        return reject(`Unable to parse JSON for feature service response ${body}: ${err}`);
       }
 
       const features = featuresCollection && featuresCollection.features;
       if (!features) {
-        reject(`Unable to look up features in feature service response: ${body}`);
-        return;
+        return reject(`Unable to look up features in feature service response: ${body}`);
       }
 
       resolve(features);

--- a/src/clients/storage/BlobStorageFactsManager.js
+++ b/src/clients/storage/BlobStorageFactsManager.js
@@ -55,7 +55,7 @@ module.exports = {
         }
         else {
           console.log(`error [${error}]`);
-          reject(error);
+          return reject(error);
         }
       });
     }).then(blobs => {

--- a/src/clients/translator/MsftTranslator.js
+++ b/src/clients/translator/MsftTranslator.js
@@ -19,7 +19,7 @@ function TranslatorAccessTokenExpired() {
   if (translatorToken && translatorToken.expires > Date.now()) {
     console.log('token missing/expired');
     return false;
-  }else{
+  } else {
     return true;
   }
 }

--- a/src/clients/translator/MsftTranslator.js
+++ b/src/clients/translator/MsftTranslator.js
@@ -43,9 +43,8 @@ function getAccessTokenForTranslation() {
   return new Promise((resolve, reject) => {
     request.post(POST, (err, response, body) => {
       if (response.statusCode !== 200 || err) {
-        reject(err);
-      }
-      else {
+        return reject(err);
+      } else {
         body = JSON.parse(body);
         resolve({
           'token': body.access_token,
@@ -73,15 +72,14 @@ function TranslateSentenceArray(access_token, wordsToTranslate, fromLanguage, to
   return new Promise((resolve, reject) => {
     request.post(POST, (err, response, body) => {
       if (err || !response || response.statusCode !== 200) {
-        reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
-      }
-      else {
+        return reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
+      } else {
         xml2js.parseString(body, (err, result) => {
           if (!err & !!result && result.ArrayOfTranslateArrayResponse && result.ArrayOfTranslateArrayResponse.TranslateArrayResponse) {
             const translatedPhrases = result.ArrayOfTranslateArrayResponse.TranslateArrayResponse;
             resolve(wordsToTranslate.map((phrase, index)=>Object.assign({}, {originalSentence: phrase, translatedSentence: translatedPhrases[index].TranslatedText})));
           } else {
-            reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
+            return reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
           }
         });
       }
@@ -101,14 +99,13 @@ function TranslateSentence(access_token, sentence, fromLanguage, toLanguage) {
   return new Promise((resolve, reject) => {
     request(options, function (err, response, body) {
       if (err || !response || response.statusCode !== 200) {
-        reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
-      }
-      else {
+        return reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
+      } else {
         xml2js.parseString(body, (err, result) => {
           if (!err & !!result && !!result['string'] && !!result['string']['_']) {
             resolve(result['string']['_']);
           } else {
-            reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
+            return reject(err || 'Failed to pull data from: ' + JSON.stringify(response));
           }
         });
       }

--- a/src/resolvers-cassandra/Edges/mutations.js
+++ b/src/resolvers-cassandra/Edges/mutations.js
@@ -20,7 +20,7 @@ function addKeywords(args, res) { // eslint-disable-line no-unused-vars
  */
 function saveLocations(args, res) { // eslint-disable-line no-unused-vars
   return new Promise((resolve, reject) => { // eslint-disable-line no-unused-vars
-    reject(
+    return reject(
       'This API call is no longer supported. ' +
       'We now automatically filter events down to only those ' +
       'locations defined in the geo-fence for your site'
@@ -34,7 +34,7 @@ function saveLocations(args, res) { // eslint-disable-line no-unused-vars
  */
 function removeLocations(args, res) { // eslint-disable-line no-unused-vars
   return new Promise((resolve, reject) => { // eslint-disable-line no-unused-vars
-    reject(
+    return reject(
       'This API call is no longer supported. ' +
       'We now automatically filter events down to only those ' +
       'locations defined in the geo-fence for your site'

--- a/src/resolvers-cassandra/Messages/queries.js
+++ b/src/resolvers-cassandra/Messages/queries.js
@@ -40,15 +40,13 @@ function event(args, res) { // eslint-disable-line no-unused-vars
   return new Promise((resolve, reject) => {
     const eventId = args && args.messageId;
     if (!eventId) {
-      reject('No event id to fetch specified');
-      return;
+      return reject('No event id to fetch specified');
     }
 
     cassandraConnector.executeQuery(eventById, [eventId])
     .then(rows => {
       if (rows.length > 1) {
-        reject(`Got more ${rows.length} events with id ${eventId}`);
-        return;
+        return reject(`Got more ${rows.length} events with id ${eventId}`);
       }
 
       const ev = rows[0];

--- a/src/resolvers-cassandra/Messages/queries.js
+++ b/src/resolvers-cassandra/Messages/queries.js
@@ -85,8 +85,8 @@ function event(args, res) { // eslint-disable-line no-unused-vars
 function translate(args, res) { // eslint-disable-line no-unused-vars
   return new Promise((resolve, reject) => {
     translatorService.translate(args.sentence, args.fromLanguage, args.toLanguage)
-          .then(result => resolve({ translatedSentence: result.translatedSentence, originalSentence: args.sentence }))
-          .catch(err => reject(err));
+      .then(result => resolve({ translatedSentence: result.translatedSentence, originalSentence: args.sentence }))
+      .catch(err => reject(err));
   });
 }
 
@@ -97,8 +97,8 @@ function translate(args, res) { // eslint-disable-line no-unused-vars
 function translateWords(args, res) { // eslint-disable-line no-unused-vars
   return new Promise((resolve, reject) => {
     translatorService.translateSentenceArray(args.words, args.fromLanguage, args.toLanguage)
-          .then(result => resolve({ words: result.translatedSentence }))
-          .catch(err => reject(err));
+      .then(result => resolve({ words: result.translatedSentence }))
+      .catch(err => reject(err));
   });
 }
 

--- a/src/resolvers-cassandra/Messages/queries.js
+++ b/src/resolvers-cassandra/Messages/queries.js
@@ -72,9 +72,9 @@ function event(args, res) { // eslint-disable-line no-unused-vars
           }
         });
       })
-      .catch(err => reject(err));
+      .catch(reject);
     })
-    .catch(err => reject(err));
+    .catch(reject);
   });
 }
 
@@ -86,7 +86,7 @@ function translate(args, res) { // eslint-disable-line no-unused-vars
   return new Promise((resolve, reject) => {
     translatorService.translate(args.sentence, args.fromLanguage, args.toLanguage)
       .then(result => resolve({ translatedSentence: result.translatedSentence, originalSentence: args.sentence }))
-      .catch(err => reject(err));
+      .catch(reject);
   });
 }
 
@@ -98,7 +98,7 @@ function translateWords(args, res) { // eslint-disable-line no-unused-vars
   return new Promise((resolve, reject) => {
     translatorService.translateSentenceArray(args.words, args.fromLanguage, args.toLanguage)
       .then(result => resolve({ words: result.translatedSentence }))
-      .catch(err => reject(err));
+      .catch(reject);
   });
 }
 


### PR DESCRIPTION
1. Always use `catch(reject)` for simple promise error handling.
2. Whitespace fixes
3. When rejecting a promise, inline the return.

No functional change.