### PR TITLE
Allow environment to override http/https for apis

### DIFF
--- a/src/clients/facebook/FacebookAnalyticsClient.js
+++ b/src/clients/facebook/FacebookAnalyticsClient.js
@@ -4,10 +4,10 @@ const Promise = require('promise');
 const request = require('request');
 
 const accessToken = process.env.FACEBOOK_AUTH_TOKEN;
-const apiHost = process.env.FACEBOOK_API_HOST || 'graph.facebook.com';
+const apiHost = process.env.FACEBOOK_API_HOST || 'https://graph.facebook.com';
 
 function buildFeedUri(pageId) {
-  return `https://${apiHost}/v2.9/${pageId}/feed`
+  return `${apiHost}/v2.9/${pageId}/feed`
     + `?access_token=${accessToken}`
     + '&format=json';
 }

--- a/src/clients/locations/FeatureServiceClient.js
+++ b/src/clients/locations/FeatureServiceClient.js
@@ -6,19 +6,19 @@ const request = require('request');
 const apiHost = process.env.FORTIS_FEATURE_SERVICE_HOST;
 
 function formatIdsUri(ids) {
-  return `http://${apiHost}/features/id/${ids.map(encodeURIComponent).join(',')}?include=bbox`;
+  return `${apiHost}/features/id/${ids.map(encodeURIComponent).join(',')}?include=bbox`;
 }
 
 function formatBboxUri(north, west, south, east) {
-  return `http://${apiHost}/features/bbox/${north}/${west}/${south}/${east}`;
+  return `${apiHost}/features/bbox/${north}/${west}/${south}/${east}`;
 }
 
 function formatPointUri(latitude, longitude) {
-  return `http://${apiHost}/features/point/${latitude}/${longitude}`;
+  return `${apiHost}/features/point/${latitude}/${longitude}`;
 }
 
 function formatNameUri(names) {
-  return `http://${apiHost}/features/name/${names.map(encodeURIComponent).join(',')}`;
+  return `${apiHost}/features/name/${names.map(encodeURIComponent).join(',')}`;
 }
 
 function callFeatureService(uri) {


### PR DESCRIPTION
As per standup today: environment variables should be able to override whether we talk to services via http or https.