### PR TITLE
Rename Host to UrlBase

### DIFF
--- a/src/clients/facebook/FacebookAnalyticsClient.js
+++ b/src/clients/facebook/FacebookAnalyticsClient.js
@@ -4,10 +4,10 @@ const Promise = require('promise');
 const request = require('request');
 
 const accessToken = process.env.FACEBOOK_AUTH_TOKEN;
-const apiHost = process.env.FACEBOOK_API_HOST || 'https://graph.facebook.com';
+const apiUrlBase = process.env.FACEBOOK_API_HOST || 'https://graph.facebook.com';
 
 function buildFeedUri(pageId) {
-  return `${apiHost}/v2.9/${pageId}/feed`
+  return `${apiUrlBase}/v2.9/${pageId}/feed`
     + `?access_token=${accessToken}`
     + '&format=json';
 }

--- a/src/clients/locations/FeatureServiceClient.js
+++ b/src/clients/locations/FeatureServiceClient.js
@@ -3,22 +3,22 @@
 const Promise = require('promise');
 const request = require('request');
 
-const apiHost = process.env.FORTIS_FEATURE_SERVICE_HOST;
+const apiUrlBase = process.env.FORTIS_FEATURE_SERVICE_HOST;
 
 function formatIdsUri(ids) {
-  return `${apiHost}/features/id/${ids.map(encodeURIComponent).join(',')}?include=bbox`;
+  return `${apiUrlBase}/features/id/${ids.map(encodeURIComponent).join(',')}?include=bbox`;
 }
 
 function formatBboxUri(north, west, south, east) {
-  return `${apiHost}/features/bbox/${north}/${west}/${south}/${east}`;
+  return `${apiUrlBase}/features/bbox/${north}/${west}/${south}/${east}`;
 }
 
 function formatPointUri(latitude, longitude) {
-  return `${apiHost}/features/point/${latitude}/${longitude}`;
+  return `${apiUrlBase}/features/point/${latitude}/${longitude}`;
 }
 
 function formatNameUri(names) {
-  return `${apiHost}/features/name/${names.map(encodeURIComponent).join(',')}`;
+  return `${apiUrlBase}/features/name/${names.map(encodeURIComponent).join(',')}`;
 }
 
 function callFeatureService(uri) {


### PR DESCRIPTION
As per @jcjimenez's [comment](https://github.com/CatalystCode/project-fortis-services/pull/44#discussion_r125698379), renaming all `host` references to `urlBase` to avoid confusion.

No functional change.