### PR TITLE
Apply markdown lint fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ After installing a fresh copy of Cassandra, you will need to run the DDL initial
 
 ```sh
 curl -O https://raw.githubusercontent.com/CatalystCode/fortisdeploy/master/ops/storage-ddls/cassandra-setup.cql
-cat cassandra-setup.cql | cqlsh
+cqlsh < cassandra-setup.cql
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+# fortis-services
+
 [![Travis CI status](https://api.travis-ci.org/CatalystCode/project-fortis-services.svg?branch=master)](https://travis-ci.org/CatalystCode/project-fortis-services)
 
-# fortis-services
 A node-based azure web app meant to host express web services
 
 ## Environment variables
@@ -19,14 +20,16 @@ FORTIS_FEATURE_SERVICE_HOST="..."
 ```
 
 ## Development Setup
+
 In order to serve data from the GraphQL services, you will need to a functioning Cassandra installation.
 
 ### Setting Up Cassandra on Windows Linux Subsystem (Ubuntu)
+
 As a prerequisite to setting up Cassandra, you will need to make sure you have Java 8 or better setup.
 
 Then follow these commands to dowloand and run your local Cassandra instance:
 
-```
+```sh
 curl http://www-eu.apache.org/dist/cassandra/3.11.0/apache-cassandra-3.11.0-bin.tar.gz > apache-cassandra-3.11.0-bin.tar.gz
 tar xfz apache-cassandra-3.11.0-bin.tar.gz
 sudo mv apache-cassandra-3.11.0 /opt/apache-cassandra-3.11.0
@@ -39,18 +42,19 @@ cassandra
 ```
 
 ### Setting Up Cassandra on Mac OS X
+
 The easiest way to do this is to use Hombrew.
 
-```
+```sh
 brew install cassandra
 brew services start cassandra
 ```
 
 ### First Casssandra Migration
+
 After installing a fresh copy of Cassandra, you will need to run the DDL initialization statements in:
 
-```
+```sh
 curl https://raw.githubusercontent.com/CatalystCode/fortisdeploy/master/ops/storage-ddls/cassandra-setup.cql > cassandra-setup.cql
 cat cassandra-setup.cql | cqlsh
 ```
-

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ As a prerequisite to setting up Cassandra, you will need to make sure you have J
 Then follow these commands to dowloand and run your local Cassandra instance:
 
 ```sh
-curl http://www-eu.apache.org/dist/cassandra/3.11.0/apache-cassandra-3.11.0-bin.tar.gz > apache-cassandra-3.11.0-bin.tar.gz
+curl -O http://www-eu.apache.org/dist/cassandra/3.11.0/apache-cassandra-3.11.0-bin.tar.gz
 tar xfz apache-cassandra-3.11.0-bin.tar.gz
 sudo mv apache-cassandra-3.11.0 /opt/apache-cassandra-3.11.0
 
@@ -55,6 +55,6 @@ brew services start cassandra
 After installing a fresh copy of Cassandra, you will need to run the DDL initialization statements in:
 
 ```sh
-curl https://raw.githubusercontent.com/CatalystCode/fortisdeploy/master/ops/storage-ddls/cassandra-setup.cql > cassandra-setup.cql
+curl -O https://raw.githubusercontent.com/CatalystCode/fortisdeploy/master/ops/storage-ddls/cassandra-setup.cql
 cat cassandra-setup.cql | cqlsh
 ```


### PR DESCRIPTION
Also: a few nitpicky changes to the bash commands in the readme.

Reference: [vscode-markdownlint](https://github.com/DavidAnson/vscode-markdownlint)