### PR TITLE
Rename mutation property in comment to query

### DIFF
--- a/src/clients/cassandra/CassandraConnector.js
+++ b/src/clients/cassandra/CassandraConnector.js
@@ -24,7 +24,7 @@ const options = {
 const client = new cassandra.Client(options);
 
 /**
- * @param {Array<{mutation: string, params: Array<string|map>}>} mutations
+ * @param {Array<{query: string, params: Array<string|map>}>} mutations
  * @returns {Promise}
  */
 function executeBatchMutations(mutations) {


### PR DESCRIPTION
No functional change. 

`executeBatchMutations` performs `client.batch`. `client.batch` accepts an array of `{query: string, params: Array<string|map>}` not `{mutation: string, params: Array<string|map>}`.