### PR TITLE
Remove all OR references

### DIFF
--- a/src/utils/collections.js
+++ b/src/utils/collections.js
@@ -14,7 +14,21 @@ function makeSet(iterable, func) {
   return set;
 }
 
+function cross(a, b) {
+  if (!a || !a.length) return b.map(item => ({right: item}));
+  if (!b || !b.length) return a.map(item => ({left: item}));
+
+  const crossProduct = [];
+  for (let i = 0; i < a.length; i++) {
+    for (let j = 0; j < b.length; j++) {
+      crossProduct.push({left: a[i], right: b[j]});
+    }
+  }
+  return crossProduct;
+}
+
 module.exports = {
+  cross: cross,
   makeMap: makeMap,
   makeSet: makeSet
 };


### PR DESCRIPTION
Cassandra doesn't support disjunctive queries so we need to work around this. For now, executing multiple queries in parallel and joining the results in memory is the least time-intensive way to implement this. Going forward, we should make an audit of our query needs and review if our schema supports all of those operations in a more idiomatic way (e.g. Cassandra secondary indices won't scale!)