### PR TITLE
Memoize locations for bounding box

### DIFF
--- a/src/resolvers-cassandra/Edges/queries.js
+++ b/src/resolvers-cassandra/Edges/queries.js
@@ -3,7 +3,7 @@
 const Promise = require('promise');
 const cassandraConnector = require('../../clients/cassandra/CassandraConnector');
 const featureServiceClient = require('../../clients/locations/FeatureServiceClient');
-const { tilesForBbox, parseTimespan, parseFromToDate, withRunTime, toPipelineKey, toConjunctionTopics } = require('../shared');
+const { fetchBboxLocations, tilesForBbox, parseTimespan, parseFromToDate, withRunTime, toPipelineKey, toConjunctionTopics } = require('../shared');
 const { makeSet, makeMap, makeMultiMap } = require('../../utils/collections');
 const { trackEvent } = require('../../clients/appinsights/AppInsightsClient');
 
@@ -57,8 +57,7 @@ function locations(args, res) { // eslint-disable-line no-unused-vars
       if (rows.length > 1) return reject(`More than one geofence configured for site ${args.site}`);
       if (!rows[0].geofence || rows[0].geofence.length !== 4) return reject(`Bad geofence for site ${args.site}`);
 
-      const bbox = rows[0].geofence;
-      return featureServiceClient.fetchByBbox({north: bbox[0], west: bbox[1], south: bbox[2], east: bbox[3]});
+      return fetchBboxLocations(rows[0].geofence);
     })
     .then(locations => {
       resolve({

--- a/src/resolvers-cassandra/Messages/queries.js
+++ b/src/resolvers-cassandra/Messages/queries.js
@@ -3,8 +3,7 @@
 const Promise = require('promise');
 const translatorService = require('../../clients/translator/MsftTranslator');
 const cassandraConnector = require('../../clients/cassandra/CassandraConnector');
-const featureServiceClient = require('../../clients/locations/FeatureServiceClient');
-const { parseFromToDate, withRunTime, toPipelineKey, toConjunctionTopics, limitForInClause } = require('../shared');
+const { fetchBboxLocations, parseFromToDate, withRunTime, toPipelineKey, toConjunctionTopics, limitForInClause } = require('../shared');
 const { makeSet } = require('../../utils/collections');
 const trackEvent = require('../../clients/appinsights/AppInsightsClient').trackEvent;
 
@@ -50,7 +49,7 @@ function byBbox(args, res) { // eslint-disable-line no-unused-vars
 
     const { fromDate, toDate } = parseFromToDate(args.fromDate, args.toDate);
 
-    featureServiceClient.fetchByBbox({north: args.bbox[0], west: args.bbox[1], south: args.bbox[2], east: args.bbox[3]})
+    fetchBboxLocations(args.bbox)
     .then(places => {
       const placeIds = makeSet(places, place => place.id);
       const limit = args.limit || 15;

--- a/src/resolvers-cassandra/Tiles/queries.js
+++ b/src/resolvers-cassandra/Tiles/queries.js
@@ -3,8 +3,7 @@
 const Promise = require('promise');
 const geotile = require('geotile');
 const cassandraConnector = require('../../clients/cassandra/CassandraConnector');
-const featureServiceClient = require('../../clients/locations/FeatureServiceClient');
-const { tilesForBbox, parseFromToDate, withRunTime, toConjunctionTopics, toPipelineKey } = require('../shared');
+const { fetchBboxLocations, tilesForBbox, parseFromToDate, withRunTime, toConjunctionTopics, toPipelineKey } = require('../shared');
 const { trackEvent } = require('../../clients/appinsights/AppInsightsClient');
 const { makeSet } = require('../../utils/collections');
 
@@ -105,7 +104,7 @@ function fetchPlacesByBBox(args, res) { // eslint-disable-line no-unused-vars
     if (!args || !args.bbox) return reject('No bounding box for which to fetch places specified');
     if (args.bbox.length !== 4) return reject('Invalid bounding box for which to fetch places specified');
 
-    featureServiceClient.fetchByBbox({north: args.bbox[0], west: args.bbox[1], south: args.bbox[2], east: args.bbox[3]})
+    fetchBboxLocations(args.bbox)
     .then(places => {
       const features = places.map(place => ({coordinate: place.bbox, name: place.name, id: place.id}));
       resolve({

--- a/src/resolvers-cassandra/shared.js
+++ b/src/resolvers-cassandra/shared.js
@@ -2,6 +2,8 @@
 
 const Promise = require('promise');
 const geotile = require('geotile');
+const memoize = require('lodash/memoize');
+const featureServiceClient = require('../clients/locations/FeatureServiceClient');
 
 function withRunTime(promiseFunc) {
   function runTimer() {
@@ -85,7 +87,12 @@ function parseFromToDate(fromDate, toDate) {
   };
 }
 
+const fetchBboxLocations = memoize((bbox) => {
+  return featureServiceClient.fetchByBbox({north: bbox[0], west: bbox[1], south: bbox[2], east: bbox[3]});
+}, (bbox) => bbox.join('|'));
+
 module.exports = {
+  fetchBboxLocations,
   parseFromToDate,
   parseTimespan,
   toPipelineKey,


### PR DESCRIPTION
@erikschlegel mentioned that it would be good to get rid of the feature service call to fetch the locations inside of a bounding box. This is non-trivial to do by changing the schema of the eventplaces table.

```cql
CREATE TABLE eventplaces(
    eventids set<text>,
    conjunctiontopic1 text,
    conjunctiontopic2 text,
    conjunctiontopic3 text,
    placeid text,
    eventtime timestamp,
    pipelinekey text,
    externalsourceid text,
    PRIMARY KEY ((placeid), conjunctiontopic1, conjunctiontopic2, conjunctiontopic3, pipelinekey, externalsourceid, eventtime)
);
```

Currently the table is keyed off of placeid which we get back from the feature service after querying for all the places in the bounding box. If we change the table to include the place x/y coordinates, we'd need to include the x/y in the key to keep the uniqueness of every row. However, we can't use primary key columns in a range query:

![pasted image at 2017_08_07 10_15 am](https://user-images.githubusercontent.com/1086421/29038304-1e17c59e-7b5c-11e7-98e1-e7e9b5088698.png)

Simply caching the bounding box place results should give us quite a lot of the value already as the bounding box calls should always be for the same value as we don't expect the bounding box to be changed once the site is set up.