### PR TITLE
Pre-compute all places inside of the site geofence

### DIFF
--- a/src/resolvers-cassandra/Edges/queries.js
+++ b/src/resolvers-cassandra/Edges/queries.js
@@ -41,28 +41,20 @@ function locations(args, res) { // eslint-disable-line no-unused-vars
   return new Promise((resolve, reject) => {
     if (!args || !args.site) return reject('No site specified for which to lookup locations');
 
-    const query = `
-    SELECT geofence
+    const placesQuery = `
+    SELECT places
     FROM fortis.sitesettings
     WHERE sitename = ?
     `.trim();
 
-    const params = [
-      args.sitename
+    const placesParams = [
+      args.site
     ];
 
-    cassandraConnector.executeQuery(query, params)
-    .then(rows => {
-      if (!rows || !rows.length) return reject(`No geofence configured for site ${args.site}`);
-      if (rows.length > 1) return reject(`More than one geofence configured for site ${args.site}`);
-      if (!rows[0].geofence || rows[0].geofence.length !== 4) return reject(`Bad geofence for site ${args.site}`);
-
-      const bbox = rows[0].geofence;
-      return featureServiceClient.fetchByBbox({north: bbox[0], west: bbox[1], south: bbox[2], east: bbox[3]});
-    })
-    .then(locations => {
+    cassandraConnector.executeQuery(placesQuery, placesParams)
+    .then(places => {
       resolve({
-        edges: locations.map(location => ({name: location.name, coordinates: location.bbox}))
+        edges: places.map(place => ({name: place.name, coordinates: place.bbox}))
       });
     })
     .catch(reject);

--- a/src/resolvers-cassandra/Messages/queries.js
+++ b/src/resolvers-cassandra/Messages/queries.js
@@ -3,6 +3,7 @@
 const Promise = require('promise');
 const translatorService = require('../../clients/translator/MsftTranslator');
 const cassandraConnector = require('../../clients/cassandra/CassandraConnector');
+const featureServiceClient = require('../../clients/locations/FeatureServiceClient');
 const { parseFromToDate, withRunTime, toPipelineKey, toConjunctionTopics, limitForInClause } = require('../shared');
 const { makeSet } = require('../../utils/collections');
 const trackEvent = require('../../clients/appinsights/AppInsightsClient').trackEvent;
@@ -45,24 +46,12 @@ function byLocation(args, res) { // eslint-disable-line no-unused-vars
  */
 function byBbox(args, res) { // eslint-disable-line no-unused-vars
   return new Promise((resolve, reject) => {
-    if (!args || !args.site) return reject('Invalid or no site specified');
+    if (!args || !args.bbox || args.bbox.length !== 4) return reject('Invalid or no bounding box specified');
 
     const { fromDate, toDate } = parseFromToDate(args.fromDate, args.toDate);
 
-    const placesQuery = `
-    SELECT places
-    FROM fortis.sitesettings
-    WHERE sitename = ?
-    `.trim();
-
-    const placesParams = [
-      args.site
-    ];
-
-    cassandraConnector.executeQuery(placesQuery, placesParams)
+    featureServiceClient.fetchByBbox({north: args.bbox[0], west: args.bbox[1], south: args.bbox[2], east: args.bbox[3]})
     .then(places => {
-      if (!places || !places.length) return reject(`No places configured for site ${args.site}`);
-
       const placeIds = makeSet(places, place => place.id);
       const limit = args.limit || 15;
 


### PR DESCRIPTION
This is a follow-up to the abandoned pull request https://github.com/CatalystCode/project-fortis-services/pull/89

At site creation time, we do a single call to fetch all the place ids inside of the geofence defined for the Fortis deployment. Later, we can then just read back these place detail from Cassandra instead of having
to hit the feature service over and over again. This is desirable over the approach taken in the linked pull request as we only have to hit the feature service once ever (instead of once per user session) and because
we reduce the amount of data that we have to cache in memory on the GraphQL server (there may be many places in a geofence).

The requisite schema change is in https://github.com/CatalystCode/project-fortis-pipeline/pull/96