### PR TITLE
Block server start until Cassandra is initialized

### DIFF
--- a/server.js
+++ b/server.js
@@ -70,6 +70,6 @@ function startServer() {
 
 const serverStartBlocker = process.env.ENABLE_V2
   ? require('./src/clients/cassandra/CassandraConnector').initialize()
-  : Promise.resolve();
+  : require('promise').resolve();
 
 serverStartBlocker.then(startServer);

--- a/server.js
+++ b/server.js
@@ -72,4 +72,4 @@ const serverStartBlocker = process.env.ENABLE_V2
   ? require('./src/clients/cassandra/CassandraConnector').initialize()
   : require('promise').resolve();
 
-serverStartBlocker.then(startServer);
+serverStartBlocker.then(startServer).catch(console.error);

--- a/server.js
+++ b/server.js
@@ -35,8 +35,6 @@ app.use(function(req, res, next) {
   }
 });
 
-console.log('PORT: ' + port);
-
 app.use(bodyParser.json({limit: '50mb'}));
 app.use(bodyParser.urlencoded({limit: '50mb', extended: true}));
 
@@ -64,6 +62,14 @@ app.use('/api/settings', graphqlHTTP({
   graphiql: true
 }));
 
-const server = http.createServer(app);
+function startServer() {
+  console.log(`PORT: ${port}`);
+  const server = http.createServer(app);
+  server.listen(port, function () {});
+}
 
-server.listen(port, function () {});
+const serverStartBlocker = process.env.ENABLE_V2
+  ? require('./src/clients/cassandra/CassandraConnector').initialize()
+  : Promise.resolve();
+
+serverStartBlocker.then(startServer);

--- a/src/clients/cassandra/CassandraConnector.js
+++ b/src/clients/cassandra/CassandraConnector.js
@@ -108,7 +108,17 @@ function executeQueries(queries) {
   });
 }
 
+/**
+ * Should be called on server start to warm up the connection to
+ * Cassandra so that subsequent calls are fast.
+ * @returns {Promise}
+ */
+function intialize() {
+  return executeQuery('select sitename from fortis.sitesettings limit 1', []);
+}
+
 module.exports = {
+  initialize: trackDependency(intialize, 'Cassandra', 'initialize'),
   executeBatchMutations: trackDependency(executeBatchMutations, 'Cassandra', 'executeBatchMutations'),
   executeQueries: trackDependency(executeQueries, 'Cassandra', 'executeQueries'),
   executeQuery: trackDependency(executeQuery, 'Cassandra', 'executeQuery')


### PR DESCRIPTION
The first request to Cassandra is very slow (on the order of 20 seconds
during my testing), I reckon because the connection and pool are being
built up. Subsequent requests are much faster (sub-second).

We don't want our users to have a problem with hitting the slow first
request, so we should warm up the Cassandra connection before we let the
server start. In this way, when we re-deploy the GraphQL server, we'll
simply continue running the instances of the old code in the load
balancer until the new server is fully operational and has warmed up the
Cassandra connection.