### PR TITLE
Rename insertion_time to insertiontime

### DIFF
--- a/src/resolvers-cassandra/Settings/mutations.js
+++ b/src/resolvers-cassandra/Settings/mutations.js
@@ -31,7 +31,7 @@ function _insertTopics(siteType) {
     blobStorageClient.fetchJson(uri)
     .then(response => {
       return response.map(topic => ({
-        query: `INSERT INTO fortis.watchlist (topicid,topic,lang_code,translations,insertion_time) 
+        query: `INSERT INTO fortis.watchlist (topicid,topic,lang_code,translations,insertiontime) 
                 VALUES (?, ?, ?, ?, toTimestamp(now()));`,
         params: [uuid(), topic.topic, topic.lang_code, topic.translations]
       }));
@@ -75,7 +75,7 @@ function createSite(args, res) { // eslint-disable-line no-unused-vars
           title,
           sitename,
           languages,
-          insertion_time
+          insertiontime
         ) VALUES (?,?,?,?,?,?,toTimestamp(now()))`,
         params: [
           args.input.targetBbox,
@@ -174,7 +174,7 @@ function modifyFacebookPages(args, res) { // eslint-disable-line no-unused-vars
       const params = facebookPagePrimaryKeyValuesToRowKey([TRUSTED_SOURCES_CONNECTOR_FACEBOOK, page.pageUrl, 'FacebookPost']);
       params.push(TRUSTED_SOURCES_RANK_DEFAULT);
       mutations.push({
-        query: 'INSERT INTO fortis.trustedsources (connector, sourceid, sourcetype, insertion_time, rank) VALUES (?, ?, ?, dateof(now()), ?)',
+        query: 'INSERT INTO fortis.trustedsources (connector, sourceid, sourcetype, insertiontime, rank) VALUES (?, ?, ?, dateof(now()), ?)',
         params: params
       });
       expectedRecords.push(normalizedFacebookPage(params));
@@ -236,7 +236,7 @@ function modifyTrustedTwitterAccounts(args, res) { // eslint-disable-line no-unu
     const accounts = args && args.input && args.input.accounts;
     if (!accounts || !accounts.length) return reject('No accounts specified');
     
-    const statement = 'INSERT INTO fortis.trustedsources (connector, sourceid, sourcetype, insertion_time, rank) VALUES (?, ?, ?, dateof(now()), ?)';
+    const statement = 'INSERT INTO fortis.trustedsources (connector, sourceid, sourcetype, insertiontime, rank) VALUES (?, ?, ?, dateof(now()), ?)';
     const queries = accounts.map(account => {
       const params = trustedTwitterAccountRowKeyToPrimaryKey(account);
       params.push(TRUSTED_SOURCES_RANK_DEFAULT);


### PR DESCRIPTION
This change is needed because `insertion_time` was changed to `insertiontime` in `cassandra-setup.cql`
see: https://github.com/CatalystCode/project-fortis-pipeline/blob/master/ops/storage-ddls/cassandra-setup.cql#L81