### PR TITLE
Fix typo

### DIFF
--- a/src/resolvers-cassandra/Edges/queries.js
+++ b/src/resolvers-cassandra/Edges/queries.js
@@ -161,7 +161,7 @@ function timeSeries(args, res) { // eslint-disable-line no-unused-vars
 
     const params = [
       periodType,
-      ...toConjunctionTopics(args.mainTerm),
+      ...toConjunctionTopics(args.mainEdge),
       args.zoomLevel,
       period,
       toPipelineKey(args.sourceFilter),


### PR DESCRIPTION
After this change, all the Edges Schema endpoints work.

Test urls:

- `http://localhost:8000/api/edges/graphiql?query=query{%0A terms(site%3A"fortis"){%0A runTime%0A edges{%0A name%0A }%0A }%0A}&operationName=undefined`
- `http://localhost:8000/api/edges/graphiql?query=query{%0A locations(site%3A"fortis"){%0A runTime%0A edges{%0A name%0A }%0A }%0A}&operationName=undefined`
- `http://localhost:8000/api/edges/graphiql?query=query{%0A popularLocations(site%3A"fortis"%2CfromDate%3A"2016"%2CtoDate%3A"2017"%2C%0A bbox%3A[-122.8217%2C47.4634%2C-121.517%2C48.0028]%2CmainEdge%3A"isis"){%0A runTime%0A edges{%0A name%0A coordinates%0A }%0A }%0A}&operationName=undefined`
- `http://localhost:8000/api/edges/graphiql?query=query{%0A timeSeries(site%3A"fortis"%2CfromDate%3A"2016"%2CtoDate%3A"2017"%2C%0A bbox%3A[48.0028%2C-122.8217%2C47.4634%2C-121.517]%2CmainEdge%3A"isis"%2C%0A zoomLevel%3A4){%0A labels{%0A name%0A mentions%0A }%0A graphData{%0A date%0A mentions%0A edges%0A }%0A }%0A}&operationName=undefined`
- `http://localhost:8000/api/edges/graphiql?query=query{%0A topSources(site%3A"fortis"%2CfromDate%3A"2016"%2CtoDate%3A"2017"%2C%0A bbox%3A[48.0028%2C-122.8217%2C47.4634%2C-121.517]%2CmainTerm%3A"isis"%2C%0A zoomLevel%3A4%2Climit%3A10){%0A sources{%0A Name%0A Count%0A Source%0A }%0A }%0A}&operationName=undefined`

Response screenshots:

![locations](https://user-images.githubusercontent.com/1086421/29425572-9680a27e-8338-11e7-8580-d14195e5693d.PNG)
![popularlocations](https://user-images.githubusercontent.com/1086421/29425568-9676e7ac-8338-11e7-894b-9441b4d0117d.PNG)
![terms](https://user-images.githubusercontent.com/1086421/29425570-967a073e-8338-11e7-9cff-52aeefb2d19b.PNG)
![timeseries](https://user-images.githubusercontent.com/1086421/29425571-967c36d0-8338-11e7-9e16-9d032f3393a1.PNG)
![topsources](https://user-images.githubusercontent.com/1086421/29425569-9677ed00-8338-11e7-82ee-c96b063629f6.PNG)
