### PR TITLE
Add siteType to EditableSiteSettings

### DIFF
--- a/src/schemas/SettingsSchema.js
+++ b/src/schemas/SettingsSchema.js
@@ -132,6 +132,7 @@ module.exports = graphql.buildSchema(`
   }
 
   input EditableSiteSettings {
+    siteType: String
     targetBbox: [Float],
     defaultZoomLevel: Int,
     logo: String,

--- a/src/schemas/SettingsSchema.js
+++ b/src/schemas/SettingsSchema.js
@@ -132,7 +132,7 @@ module.exports = graphql.buildSchema(`
   }
 
   input EditableSiteSettings {
-    siteType: String
+    siteType: String,
     targetBbox: [Float],
     defaultZoomLevel: Int,
     logo: String,


### PR DESCRIPTION
* `siteType` is needed for `createSite`, so that when a site is first created, the site can have predefined topics according to its siteType

* I made `siteType` optional, since it shouldn't be required for `removeSite` or `editSite`.