### PR TITLE
Inline CSV report creation

### DIFF
--- a/src/resolvers-cassandra/Edges/index.js
+++ b/src/resolvers-cassandra/Edges/index.js
@@ -8,12 +8,5 @@ module.exports = {
   topSources: queries.topSources,
   topTerms: queries.topTerms,
   geofenceplaces: queries.geofenceplaces,
-  conjunctiveTerms: queries.conjunctiveTopics,
-
-  csv_topLocations: queries.csv_popularLocations,
-  csv_timeSeries: queries.csv_timeSeries,
-  csv_topSources: queries.csv_topSources,
-  csv_topTerms: queries.csv_topTerms,
-  csv_geofenceplaces: queries.csv_geofenceplaces,
-  csv_conjunctiveTerms: queries.csv_conjunctiveTopics
+  conjunctiveTerms: queries.conjunctiveTopics
 };

--- a/src/schemas/EdgesSchema.js
+++ b/src/schemas/EdgesSchema.js
@@ -2,19 +2,12 @@ const graphql = require('graphql');
 
 module.exports = graphql.buildSchema(`
   type Query {
-    geofenceplaces(bbox: [Float]!): GeofencePlacesCollection
-    conjunctiveTerms(maintopic: String!, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, bbox: [Float]!, zoomLevel: Int!, externalsourceid: String!): ConjunctionTermCollection
-    timeSeries(maintopics: [String]!, fromDate: String!, toDate: String!, periodType: String!, pipelinekeys: [String]!, maintopics: [String]!, conjunctivetopics: [String], bbox: [Float]!, zoomLevel: Int!, externalsourceid: String!): FeatureTimeSeriesCollection
-    topLocations(maintopic: String!, limit: Int, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, conjunctivetopics: [String]!, bbox: [Float]!, zoomLevel: Int!, externalsourceid: String!): TopPlacesCollection
-    topSources(maintopic: String!, limit: Int, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, conjunctivetopics: [String]!, bbox: [Float]!, zoomLevel: Int!): TopSourcesCollection
-    topTerms(limit: Int, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, externalsourceid: String!, bbox: [Float]!, zoomLevel: Int): TopTermsCollection
-
-    csv_geofenceplaces(bbox: [Float]!): Csv
-    csv_conjunctiveTerms(maintopic: String!, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, bbox: [Float]!, zoomLevel: Int!, externalsourceid: String!): Csv
-    csv_timeSeries(maintopics: [String]!, fromDate: String!, toDate: String!, periodType: String!, pipelinekeys: [String]!, maintopics: [String]!, conjunctivetopics: [String], bbox: [Float]!, zoomLevel: Int!, externalsourceid: String!): Csv
-    csv_topLocations(maintopic: String!, limit: Int, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, conjunctivetopics: [String]!, bbox: [Float]!, zoomLevel: Int!, externalsourceid: String!): Csv
-    csv_topSources(maintopic: String!, limit: Int, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, conjunctivetopics: [String]!, bbox: [Float]!, zoomLevel: Int!): Csv
-    csv_topTerms(limit: Int, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, externalsourceid: String!, bbox: [Float]!, zoomLevel: Int): Csv
+    geofenceplaces(bbox: [Float]!, csv: Boolean): GeofencePlacesCollection
+    conjunctiveTerms(maintopic: String!, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, bbox: [Float]!, zoomLevel: Int!, externalsourceid: String!, csv: Boolean): ConjunctionTermCollection
+    timeSeries(maintopics: [String]!, fromDate: String!, toDate: String!, periodType: String!, pipelinekeys: [String]!, maintopics: [String]!, conjunctivetopics: [String], bbox: [Float]!, zoomLevel: Int!, externalsourceid: String!, csv: Boolean): FeatureTimeSeriesCollection
+    topLocations(maintopic: String!, limit: Int, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, conjunctivetopics: [String]!, bbox: [Float]!, zoomLevel: Int!, externalsourceid: String!, csv: Boolean): TopPlacesCollection
+    topSources(maintopic: String!, limit: Int, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, conjunctivetopics: [String]!, bbox: [Float]!, zoomLevel: Int!, csv: Boolean): TopSourcesCollection
+    topTerms(limit: Int, fromDate: String!, periodType: String!, toDate: String!, pipelinekeys: [String]!, externalsourceid: String!, bbox: [Float]!, zoomLevel: Int, csv: Boolean): TopTermsCollection
   }
 
   type Csv {
@@ -53,21 +46,25 @@ module.exports = graphql.buildSchema(`
 
   type GeofencePlacesCollection {
     places: [OsmPlace]!
+    csv: Csv
   }
 
   type TopSourcesCollection{
     runTime: String,
     edges: [ExternalSource]!
+    csv: Csv
   }
 
   type TopPlacesCollection{
     runTime: String,
     edges: [Place]!
+    csv: Csv
   }
 
   type TopTermsCollection{
     runTime: String,
     edges: [Term]!
+    csv: Csv
   }
 
   type ConjuntiveTerm {
@@ -80,6 +77,7 @@ module.exports = graphql.buildSchema(`
   type ConjunctionTermCollection {
     runTime: String
     edges: [ConjuntiveTerm]!
+    csv: Csv
   }
 
   type TimeSeriesLabel {
@@ -90,6 +88,7 @@ module.exports = graphql.buildSchema(`
     labels: [TimeSeriesLabel]!
     graphData: [TimeSeriesEntry]!
     tiles: [String]
+    csv: Csv
   }
 
   type TimeSeriesEntry{


### PR DESCRIPTION
Due to how the frontend project is set up, this approach will be easier to consume from the frontend than making a separate graphql call since we can just toggle the csv include via flux.