### PR TITLE
Streams final

### DIFF
--- a/src/clients/appinsights/LoggingClient.js
+++ b/src/clients/appinsights/LoggingClient.js
@@ -37,6 +37,31 @@ function termsExtraProps() {
   });
 }
 
+function streamsExtraProps() {
+  return () => ({
+    operation: 'query',
+    table: 'streams',
+    success: 'true'
+  });
+}
+
+function modifyStreamsExtraProps() {
+  return () => ({
+    operation: 'modify',
+    table: 'streams',
+    success: 'true'
+  });
+}
+
+function streamsExtraMetrics() {
+  return (graphqlResult) => {
+    const totalRows = graphqlResult.streams.length;
+    return {
+      totalRows
+    };
+  };
+}
+
 function addKeywordsExtraProps() {
   return () => ({
     operation: 'modify',
@@ -55,7 +80,7 @@ function removeKeywordsExtraProps() {
 
 function keywordsExtraMetrics() {
   return (graphqlResult) => {
-    const totalRows = graphqlResult.edges.length; //TODO
+    const totalRows = graphqlResult.edges.length;
     return {
       totalRows
     };
@@ -78,6 +103,17 @@ function logNoKeywordsToRemove() {
     client: constants.CLIENTS.cassandra,
     operation: 'remove',
     table: 'watchlist',
+    success: 'false'
+  },{
+    numToMutate: 0
+  });
+}
+
+function logNoStreamParamsToEdit() {
+  trackSyncEvent('cassandra', { 
+    client: constants.CLIENTS.cassandra,
+    operation: 'modify',
+    table: 'streams',
     success: 'false'
   },{
     numToMutate: 0
@@ -114,11 +150,15 @@ module.exports = {
   logNoMutationsDefined,
   logExecuteQueryError,
   termsExtraProps,
+  streamsExtraProps,
+  modifyStreamsExtraProps,
+  streamsExtraMetrics,
   addKeywordsExtraProps,
   removeKeywordsExtraProps,
   keywordsExtraMetrics,
   logNoKeywordsToAdd,
   logNoKeywordsToRemove,
+  logNoStreamParamsToEdit,
   translateExtraProps,
   translateExtraMetrics,
   translateWordsExtraMetrics

--- a/src/resolvers-cassandra/Settings/index.js
+++ b/src/resolvers-cassandra/Settings/index.js
@@ -8,7 +8,6 @@ module.exports = {
   removeSite: mutations.removeSite,
   editSite: mutations.editSite,
   modifyStreams: mutations.modifyStreams,
-  removeStreams: mutations.removeStreams,
   modifyFacebookPages: mutations.modifyFacebookPages,
   removeFacebookPages: mutations.removeFacebookPages,
   modifyTrustedTwitterAccounts: mutations.modifyTrustedTwitterAccounts,

--- a/src/resolvers-cassandra/Settings/queries.js
+++ b/src/resolvers-cassandra/Settings/queries.js
@@ -4,7 +4,7 @@ const Promise = require('promise');
 const facebookAnalyticsClient = require('../../clients/facebook/FacebookAnalyticsClient');
 const cassandraConnector = require('../../clients/cassandra/CassandraConnector');
 const { withRunTime, getTermsByCategory, getSiteDefintion } = require('../shared');
-const { trackEvent, trackException } = require('../../clients/appinsights/AppInsightsClient').trackEvent;
+const { trackEvent, trackException } = require('../../clients/appinsights/AppInsightsClient');
 const loggingClient = require('../../clients/appinsights/LoggingClient');
 
 const PIPELINE_KEY_TWITTER = 'twitter';

--- a/src/schemas/SettingsSchema.js
+++ b/src/schemas/SettingsSchema.js
@@ -20,7 +20,6 @@ module.exports = graphql.buildSchema(`
     removeSite(input: EditableSiteSettings!): Site
     editSite(input: EditableSiteSettings!): Site
     modifyStreams(input: StreamListInput!): StreamCollection
-    removeStreams(input: StreamListInput!): StreamCollection
     removeFacebookPages(input: FacebookPageListInput!): FacebookPageCollection
     modifyFacebookPages(input: FacebookPageListInput!): FacebookPageCollection
     createOrReplaceSite(input: SiteDefinition!): Site


### PR DESCRIPTION
For issue https://github.com/CatalystCode/project-fortis-interfaces/issues/94
App insights logging:
Modify Streams:
![image](https://user-images.githubusercontent.com/7232635/31504245-e44f029c-af3f-11e7-8506-40618189871d.png)

Query Streams:
![image](https://user-images.githubusercontent.com/7232635/31504281-f8efd532-af3f-11e7-8e59-a4f349235a7a.png)

No need for remove streams service, since the user should only be able to edit stream param values and enable or disable a stream.
