### PR TITLE
Fix create_site.py failing

### DIFF
--- a/src/resolvers-cassandra/Settings/mutations.js
+++ b/src/resolvers-cassandra/Settings/mutations.js
@@ -29,8 +29,8 @@ function _insertTopics(siteType) {
     .then(response => {
       return response.map(topic => ({
         query: `INSERT INTO fortis.watchlist (topicid,topic,lang_code,translations,insertiontime,category) 
-                VALUES (?, ?, ?, ?, toTimestamp(now()));`,
-        params: [uuid(), topic.topic, topic.lang_code, topic.translations, topic.category]
+                VALUES (?, ?, ?, ?, toTimestamp(now()), ?);`,
+        params: [uuid(), topic.topic, topic.lang_code, topic.translations, topic.category || '']
       }));
     })
     .then(response => {


### PR DESCRIPTION
The createSite call was failing with an error of "Unmatched column names/values". This is due to a regression introduced in 872e1ae8 which added a param to the fortis.watchlist insertion cassandra query without adding a placeholder in the query CQL.

Additionally, the topic category is required to always be non-null so we default it to an empty string if the category is not set in the blob watchlist terms.

Tagging @erikschlegel since he requested the fix.

Here is the createSite mutation succeeding after the fix:

![image](https://user-images.githubusercontent.com/1086421/32202668-a2b97820-bdb4-11e7-87aa-d9d862d1f30f.png)

Here is the create_site.py script succeeding after the fix:

![image](https://user-images.githubusercontent.com/1086421/32202717-ef556a4a-bdb4-11e7-9b6a-926c0c783fb9.png)
